### PR TITLE
Connected Accounts page setting to dashboard(added feeatures))

### DIFF
--- a/src/app/account/page.js
+++ b/src/app/account/page.js
@@ -1,25 +1,138 @@
 "use client";
 
-import { useState } from 'react';
-import Sidebar from '../../components/Sidebar';
-import { useDarkMode } from '../DarkModeContext';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@supabase/supabase-js";
+import Sidebar from "../../components/Sidebar";
+import { useDarkMode } from "../DarkModeContext";
+
+// Supabase client (env first, then project fallback)
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://kwaylmatpkcajsctujor.supabase.co",
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt3YXlsbWF0cGtjYWpzY3R1am9yIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNDAwMjQsImV4cCI6MjA3MDgxNjAyNH0.-ZICiwnXTGWgPNTMYvirIJ3rP7nQ9tIRC1ZwJBZM96M"
+);
+
+// UI <-> DB helpers
+const TEMP_UI_TO_DB = { Fahrenheit: "F", Celsius: "C" };
+const TEMP_DB_TO_UI = { F: "Fahrenheit", C: "Celsius" };
+
+// keep DB in IANA; show a few common abbreviations in UI
+const TZ_OPTIONS = [
+  { label: "AKDT", iana: "America/Anchorage" },
+  { label: "EDT", iana: "America/New_York" },
+  { label: "PDT", iana: "America/Los_Angeles" },
+];
+const tzLabelToIana = Object.fromEntries(TZ_OPTIONS.map((o) => [o.label, o.iana]));
+const tzIanaToLabel = Object.fromEntries(TZ_OPTIONS.map((o) => [o.iana, o.label]));
 
 export default function Account() {
+  const router = useRouter();
   const { darkMode, toggleDarkMode } = useDarkMode();
+
+  const [userId, setUserId] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
   const [preferences, setPreferences] = useState({
-    tempScale: 'Fahrenheit',
-    dashboard: ['Temperature Monitoring System', 'Sensors', 'Users', 'Alerts', 'Notifications'],
-    timeZone: 'AKDT',
+    tempScale: "Fahrenheit",
+    dashboard: ["Temperature Monitoring System", "Sensors", "Users", "Alerts", "Notifications"],
+    timeZone: "AKDT",
     darkMode: false,
   });
   const [savedPreferences, setSavedPreferences] = useState(null);
 
+  // Session + load prefs
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setError("");
+
+      const { data: sessionData, error: sErr } = await supabase.auth.getSession();
+      if (sErr) {
+        setError("Failed to verify session: " + sErr.message);
+        setLoading(false);
+        router.push("/login");
+        return;
+      }
+      const session = sessionData?.session;
+      if (!session) {
+        setLoading(false);
+        router.push("/login");
+        return;
+      }
+      const uid = session.user.id;
+      setUserId(uid);
+
+      // fetch prefs row
+      const { data: row, error: rErr } = await supabase
+        .from("user_preferences")
+        .select("*")
+        .eq("user_id", uid)
+        .single();
+
+      // PGRST116 = row not found
+      if (rErr && rErr.code !== "PGRST116") {
+        setError(rErr.message || "Failed to load preferences.");
+        setLoading(false);
+        return;
+      }
+
+      if (!row) {
+        // create default row (safe with RLS)
+        const defaults = {
+          user_id: uid,
+          temp_scale: TEMP_UI_TO_DB["Fahrenheit"],
+          show_temp: true,
+          show_humidity: false,
+          show_sensors: true,
+          show_users: true,
+          show_alerts: true,
+          show_notifications: true,
+          time_zone: tzLabelToIana["AKDT"],
+          dark_mode: false,
+        };
+        await supabase.from("user_preferences").upsert(defaults, { onConflict: "user_id" });
+        // sync UI and theme
+        if (darkMode !== false) toggleDarkMode();
+        setPreferences({
+          tempScale: "Fahrenheit",
+          dashboard: ["Temperature Monitoring System", "Sensors", "Users", "Alerts", "Notifications"],
+          timeZone: "AKDT",
+          darkMode: false,
+        });
+        setLoading(false);
+        return;
+      }
+
+      // map DB -> UI
+      const ui = {
+        tempScale: TEMP_DB_TO_UI[row.temp_scale] ?? "Fahrenheit",
+        dashboard: [
+          ...(row.show_temp ? ["Temperature Monitoring System"] : []),
+          ...(row.show_humidity ? ["Humidity Monitoring System"] : []),
+          ...(row.show_sensors ? ["Sensors"] : []),
+          ...(row.show_users ? ["Users"] : []),
+          ...(row.show_alerts ? ["Alerts"] : []),
+          ...(row.show_notifications ? ["Notifications"] : []),
+        ],
+        timeZone: tzIanaToLabel[row.time_zone] ?? "AKDT",
+        darkMode: !!row.dark_mode,
+      };
+      setPreferences(ui);
+
+      // sync theme
+      if (ui.darkMode !== darkMode) toggleDarkMode();
+
+      setLoading(false);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleChange = (e) => {
-    const { name, value, type } = e.target;
-    setPreferences((prev) => ({
-      ...prev,
-      [name]: type === 'checkbox' ? e.target.checked : value,
-    }));
+    const { name, value, type, checked } = e.target;
+    setPreferences((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
   };
 
   const handleDashboardChange = (e) => {
@@ -30,237 +143,206 @@ export default function Account() {
     }));
   };
 
-  const handleSave = () => {
-    setSavedPreferences({ ...preferences });
-    if (preferences.darkMode !== darkMode) {
-      toggleDarkMode();
+  const handleSave = async () => {
+    if (!userId) return;
+    setSaving(true);
+    setError("");
+
+    try {
+      const row = {
+        user_id: userId,
+        temp_scale: TEMP_UI_TO_DB[preferences.tempScale] ?? "F",
+        show_temp: preferences.dashboard.includes("Temperature Monitoring System"),
+        show_humidity: preferences.dashboard.includes("Humidity Monitoring System"),
+        show_sensors: preferences.dashboard.includes("Sensors"),
+        show_users: preferences.dashboard.includes("Users"),
+        show_alerts: preferences.dashboard.includes("Alerts"),
+        show_notifications: preferences.dashboard.includes("Notifications"),
+        time_zone: tzLabelToIana[preferences.timeZone] ?? "America/Anchorage",
+        dark_mode: !!preferences.darkMode,
+      };
+
+      const { error: upErr } = await supabase.from("user_preferences").upsert(row, { onConflict: "user_id" });
+      if (upErr) throw upErr;
+
+      // sync global theme
+      if (preferences.darkMode !== darkMode) toggleDarkMode();
+
+      setSavedPreferences({ ...preferences });
+    } catch (err) {
+      setError(err.message || "Failed to save preferences.");
+    } finally {
+      setSaving(false);
     }
   };
 
-  const handleCloseSaved = () => {
-    setSavedPreferences(null);
-  };
+  const handleCloseSaved = () => setSavedPreferences(null);
 
+  // slider styles (unchanged from your UI)
   const sliderStyle = {
-    position: 'relative',
-    display: 'inline-block',
-    width: '60px',
-    height: '34px',
-    backgroundColor: '#4a4a4a',
-    borderRadius: '34px',
+    position: "relative",
+    display: "inline-block",
+    width: "60px",
+    height: "34px",
+    backgroundColor: "#4a4a4a",
+    borderRadius: "34px",
   };
-
   const sliderBeforeStyle = {
-    position: 'absolute',
+    position: "absolute",
     content: '""',
-    height: '26px',
-    width: '26px',
-    left: preferences.darkMode ? 'calc(100% - 30px)' : '4px',
-    bottom: '4px',
-    backgroundColor: '#fff',
-    transition: '0.4s',
-    borderRadius: '50%',
+    height: "26px",
+    width: "26px",
+    left: preferences.darkMode ? "calc(100% - 30px)" : "4px",
+    bottom: "4px",
+    backgroundColor: "#fff",
+    transition: "0.4s",
+    borderRadius: "50%",
+  };
+  const savedSliderBeforeStyle = {
+    position: "absolute",
+    content: '""',
+    height: "26px",
+    width: "26px",
+    left: savedPreferences?.darkMode ? "calc(100% - 30px)" : "4px",
+    bottom: "4px",
+    backgroundColor: "#fff",
+    transition: "0.4s",
+    borderRadius: "50%",
   };
 
-  const savedSliderBeforeStyle = {
-    position: 'absolute',
-    content: '""',
-    height: '26px',
-    width: '26px',
-    left: savedPreferences?.darkMode ? 'calc(100% - 30px)' : '4px',
-    bottom: '4px',
-    backgroundColor: '#fff',
-    transition: '0.4s',
-    borderRadius: '50%',
-  };
+  const pageShellClass = `flex min-h-screen ${darkMode ? "bg-gray-900 text-white" : "bg-gray-100 text-gray-800"}`;
+
+  const DASH_CHECKS = [
+    "Temperature Monitoring System",
+    "Humidity Monitoring System",
+    "Sensors",
+    "Users",
+    "Alerts",
+    "Notifications",
+  ];
 
   return (
-    <div className={`flex min-h-screen ${darkMode ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-800'}`}>
+    <div className={pageShellClass}>
       <Sidebar />
       <main className="flex-1 p-6">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-3xl font-bold">Account Settings</h2>
           <div className="flex items-center gap-4">
-            <button className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">Log out</button>
-            <div className="w-10 h-10 bg-amber-600 rounded-full flex items-center justify-center text-white text-sm font-bold">FA</div>
+            <button
+              onClick={async () => {
+                await supabase.auth.signOut();
+                router.push("/login");
+              }}
+              className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
+            >
+              Log out
+            </button>
+            <div className="w-10 h-10 bg-amber-600 rounded-full flex items-center justify-center text-white text-sm font-bold">
+              FA
+            </div>
           </div>
         </div>
-        <div
-          className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}
-        >
+
+        {error && (
+          <div className="mb-4 rounded border border-red-400 bg-red-50 px-4 py-3 text-red-700">{error}</div>
+        )}
+
+        <div className={`rounded-lg shadow p-6 ${darkMode ? "bg-gray-800 text-white" : "bg-white"}`}>
           <h3 className="text-xl font-semibold mb-6">Preferences</h3>
-          <div className="space-y-6">
-            <div>
-              <label className="block text-sm font-medium mb-2">Temp Scale</label>
-              <select
-                name="tempScale"
-                value={preferences.tempScale}
-                onChange={handleChange}
-                className={`border rounded px-2 py-1 w-full ${
-                  darkMode ? 'bg-gray-700 text-white border-gray-600' : 'bg-white'
-                }`}
-              >
-                <option>Fahrenheit</option>
-                <option>Celsius</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-2">Dashboard</label>
-              <p
-                className={`text-sm mb-2 ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}
-              >
-                Select which data points (if supported by your sensor) to show on the dashboard
-              </p>
-              {[
-                'Temperature Monitoring System',
-                'Humidity Monitoring System',
-                'Sensors',
-                'Users',
-                'Alerts',
-                'Notifications',
-              ].map((item) => (
-                <div key={item} className="flex items-center mb-2">
-                  <input
-                    type="checkbox"
-                    id={item}
-                    value={item}
-                    checked={preferences.dashboard.includes(item)}
-                    onChange={handleDashboardChange}
-                    className="mr-2"
-                  />
-                  <label htmlFor={item}>{item}</label>
-                </div>
-              ))}
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-2">Time Zone</label>
-              <select
-                name="timeZone"
-                value={preferences.timeZone}
-                onChange={handleChange}
-                className={`border rounded px-2 py-1 w-full ${
-                  darkMode ? 'bg-gray-700 text-white border-gray-600' : 'bg-white'
-                }`}
-              >
-                <option>AKDT</option>
-                <option>EDT</option>
-                <option>PDT</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-2">Mode</label>
-              <label style={sliderStyle} className="relative inline-block cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={preferences.darkMode}
-                  onChange={() => {
-                    toggleDarkMode();
-                    setPreferences((prev) => ({ ...prev, darkMode: !prev.darkMode }));
-                  }}
-                  className="absolute opacity-0 w-0 h-0"
-                />
-                <span style={sliderBeforeStyle} className="absolute cursor-pointer"></span>
-              </label>
-            </div>
-          </div>
-          <button
-            className={`mt-6 px-4 py-2 rounded text-white border ${
-              darkMode
-                ? 'bg-orange-700 hover:bg-orange-800 border-orange-700'
-                : 'bg-orange-500 hover:bg-orange-600 border-orange-500'
-            }`}
-            onClick={handleSave}
-          >
-            Save
-          </button>
-        </div>
-        {savedPreferences && (
-          <div
-            className={`mt-6 rounded-lg shadow p-6 ${savedPreferences.darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}
-          >
-            <div className="flex justify-between items-center mb-6">
-              <h3 className="text-xl font-semibold">Saved Preferences</h3>
-              <button
-                onClick={handleCloseSaved}
-                className="text-xl font-bold hover:text-red-500"
-                aria-label="Close saved preferences"
-              >
-                ×
-              </button>
-            </div>
+
+          {loading ? (
+            <div className="py-10 text-center opacity-80">Loading…</div>
+          ) : (
             <div className="space-y-6">
+              {/* Temp Scale */}
               <div>
                 <label className="block text-sm font-medium mb-2">Temp Scale</label>
                 <select
                   name="tempScale"
-                  value={savedPreferences.tempScale}
-                  disabled
+                  value={preferences.tempScale}
+                  onChange={handleChange}
                   className={`border rounded px-2 py-1 w-full ${
-                    savedPreferences.darkMode ? 'bg-gray-700 text-white border-gray-600' : 'bg-gray-100 text-gray-700'
+                    darkMode ? "bg-gray-700 text-white border-gray-600" : "bg-white"
                   }`}
                 >
                   <option>Fahrenheit</option>
                   <option>Celsius</option>
                 </select>
               </div>
+
+              {/* Dashboard toggles */}
               <div>
                 <label className="block text-sm font-medium mb-2">Dashboard</label>
-                <p
-                  className={`text-sm mb-2 ${savedPreferences.darkMode ? 'text-gray-400' : 'text-gray-500'}`}
-                >
-                  Saved data points based on your selection
+                <p className={`text-sm mb-2 ${darkMode ? "text-gray-400" : "text-gray-500"}`}>
+                  Select which data points (if supported by your sensor) to show on the dashboard
                 </p>
-                {[
-                  'Temperature Monitoring System',
-                  'Humidity Monitoring System',
-                  'Sensors',
-                  'Users',
-                  'Alerts',
-                  'Notifications',
-                ].map((item) => (
+                {DASH_CHECKS.map((item) => (
                   <div key={item} className="flex items-center mb-2">
                     <input
                       type="checkbox"
                       id={item}
                       value={item}
-                      checked={savedPreferences.dashboard.includes(item)}
-                      disabled
+                      checked={preferences.dashboard.includes(item)}
+                      onChange={handleDashboardChange}
                       className="mr-2"
                     />
-                    <label htmlFor={item} className="text-gray-700">{item}</label>
+                    <label htmlFor={item}>{item}</label>
                   </div>
                 ))}
               </div>
+
+              {/* Time Zone */}
               <div>
                 <label className="block text-sm font-medium mb-2">Time Zone</label>
                 <select
                   name="timeZone"
-                  value={savedPreferences.timeZone}
-                  disabled
+                  value={preferences.timeZone}
+                  onChange={handleChange}
                   className={`border rounded px-2 py-1 w-full ${
-                    savedPreferences.darkMode ? 'bg-gray-700 text-white border-gray-600' : 'bg-gray-100 text-gray-700'
+                    darkMode ? "bg-gray-700 text-white border-gray-600" : "bg-white"
                   }`}
                 >
-                  <option>AKDT</option>
-                  <option>EDT</option>
-                  <option>PDT</option>
+                  {TZ_OPTIONS.map((t) => (
+                    <option key={t.label} value={t.label}>
+                      {t.label}
+                    </option>
+                  ))}
                 </select>
               </div>
+
+              {/* Dark mode */}
               <div>
                 <label className="block text-sm font-medium mb-2">Mode</label>
                 <label style={sliderStyle} className="relative inline-block cursor-pointer">
                   <input
                     type="checkbox"
-                    checked={savedPreferences.darkMode}
-                    disabled
+                    checked={preferences.darkMode}
+                    onChange={() => {
+                      toggleDarkMode();
+                      setPreferences((prev) => ({ ...prev, darkMode: !prev.darkMode }));
+                    }}
                     className="absolute opacity-0 w-0 h-0"
                   />
-                  <span style={savedSliderBeforeStyle} className="absolute cursor-pointer"></span>
+                  <span style={sliderBeforeStyle} className="absolute cursor-pointer"></span>
                 </label>
               </div>
+
+              <button
+                className={`mt-6 px-4 py-2 rounded text-white border ${
+                  darkMode
+                    ? "bg-orange-700 hover:bg-orange-800 border-orange-700"
+                    : "bg-orange-500 hover:bg-orange-600 border-orange-500"
+                }`}
+                disabled={saving}
+                onClick={handleSave}
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
             </div>
-          </div>
-        )}
+          )}
+        </div>
+
+      
       </main>
     </div>
   );

--- a/src/app/alerts/page.js
+++ b/src/app/alerts/page.js
@@ -1,25 +1,19 @@
 'use client';
 
-import React, { useState, useRef, useEffect, Component } from 'react';
+import React, { useEffect, useMemo, useRef, useState, Component } from 'react';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@supabase/supabase-js';
 import Sidebar from '../../components/Sidebar';
 import { useDarkMode } from '../DarkModeContext';
 
-// Supabase configuration
+/* -------------------- Supabase (inline keys) -------------------- */
 const supabaseUrl = 'https://kwaylmatpkcajsctujor.supabase.co';
 const supabaseAnonKey =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt3YXlsbWF0cGtjYWpzY3R1am9yIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNDAwMjQsImV4cCI6MjA3MDgxNjAyNH0.-ZICiwnXTGWgPNTMYvirIJ3rP7nQ9tIRC1ZwJBZM96M';
 
-let supabase;
-try {
-  supabase = createClient(supabaseUrl, supabaseAnonKey);
-  console.log('Supabase client initialized successfully');
-} catch (err) {
-  console.error('Failed to initialize Supabase client:', err);
-}
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-// ---------- Error Boundary (JS) ----------
+/* -------------------- Error Boundary -------------------- */
 class ErrorBoundary extends Component {
   constructor(props) {
     super(props);
@@ -44,7 +38,42 @@ class ErrorBoundary extends Component {
   }
 }
 
-// ---------- Styles ----------
+/* -------------------- Helpers -------------------- */
+const cToF = (c) => (c * 9) / 5 + 32;
+const fToC = (f) => (f - 32) * 5 / 9;
+const toF = (val, unit) => (val == null ? null : unit === 'C' ? cToF(Number(val)) : Number(val));
+const convertForDisplay = (tempF, userScale) =>
+  tempF == null ? null : userScale === 'C' ? fToC(tempF) : tempF;
+const convertFromDisplay = (displayTemp, userScale) =>
+  displayTemp == null ? null : userScale === 'C' ? cToF(displayTemp) : tempF;
+
+const toLocalFromReading = (r) => {
+  try {
+    if (r?.approx_time) return new Date(r.approx_time).toLocaleString();
+    if (r?.timestamp != null) {
+      const n = Number(r.timestamp);
+      const ms = n > 1e12 ? n : n * 1000;
+      return new Date(ms).toLocaleString();
+    }
+  } catch {}
+  return '—';
+};
+
+/* -------------------- Status -------------------- */
+/** No defaults: if min/max missing or invalid, we mark Unconfigured */
+const computeStatus = (temp, { min, max, warning }) => {
+  if (temp == null) return 'Unconfigured';
+  if (!Number.isFinite(min) || !Number.isFinite(max) || Number(min) >= Number(max)) {
+    return 'Unconfigured';
+  }
+  const span = Number(max) - Number(min);
+  const margin = Math.max(0, Math.min(Number(warning ?? 0), span / 2)); // clamp to half-range
+  if (temp < Number(min) || temp > Number(max)) return 'Needs Attention';
+  if (temp < Number(min) + margin || temp > Number(max) - margin) return 'Warning';
+  return 'Good';
+};
+
+/* -------------------- Styles -------------------- */
 const getStatusStyles = (status, darkMode) => {
   switch (status) {
     case 'Needs Attention':
@@ -87,63 +116,30 @@ const CARD_STYLES = {
     light: 'bg-green-50 border-green-500 text-green-900',
     dark: 'bg-green-950/40 border-green-400 text-green-200',
   },
+  Unconfigured: {
+    light: 'bg-gray-50 border-gray-300 text-gray-800',
+    dark: 'bg-gray-900/40 border-gray-500 text-gray-100',
+  },
 };
-
 const cardClass = (status, darkMode) =>
   (darkMode ? CARD_STYLES[status]?.dark : CARD_STYLES[status]?.light) ||
   (darkMode ? 'bg-gray-800 border-gray-500 text-white' : 'bg-white border-gray-300 text-gray-800');
 
-// ---------- Helpers ----------
-const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
-const computeStatus = (temp, { min, max, warning = 5 }) => {
-  if (temp == null) return 'Good';
-  if (temp < min || temp > max) return 'Needs Attention';
-  if (temp <= min + warning || temp >= max - warning) return 'Warning';
-  return 'Good';
-};
 
-const toLocalFromReading = (r) => {
-  if (r?.approx_time) {
-    try { return new Date(r.approx_time).toLocaleString(); } catch {}
-  }
-  if (r?.timestamp != null) {
-    const n = Number(r.timestamp);
-    const ms = n > 1e12 ? n : n * 1000; // sec vs ms
-    try { return new Date(ms).toLocaleString(); } catch {}
-  }
-  return 'Current Reading';
-};
 
-const cToF = (c) => (c * 9) / 5 + 32;
-const fToC = (f) => (f - 32) * 5 / 9;
-const toF = (val, unit) => (val == null ? null : unit === 'C' ? cToF(Number(val)) : Number(val));
-
-// Convert temperature for display based on user preference
-const convertForDisplay = (tempF, userScale) => {
-  if (tempF == null) return null;
-  return userScale === 'C' ? fToC(tempF) : tempF;
-};
-
-// Convert display temperature back to Fahrenheit for storage
-const convertFromDisplay = (displayTemp, userScale) => {
-  if (displayTemp == null) return null;
-  return userScale === 'C' ? cToF(displayTemp) : displayTemp;
-};
-
-// ---------- Chart ----------
+/* -------------------- Chart Component -------------------- */
 function ThresholdChart({
   data,
   min,
   max,
-  warning = 5, // Default warning margin
+  warning,
   darkMode,
   onChange,
-  // Alert Detail extras:
-  sensorId,   // to fetch last 30 min + update DB
-  unit,       // 'C' | 'F' (display is °F; limits stored as °F)
-  editable,   // enables "Edit limits" UX in Alert Detail
-  userTempScale = 'F', // User's preferred temperature scale
-  sensorType = 'temperature', // 'temperature' | 'humidity'
+  sensorId,
+  unit,
+  editable,
+  userTempScale = 'F',
+  sensorType = 'temperature',
 }) {
   const svgRef = useRef(null);
   const containerRef = useRef(null);
@@ -166,9 +162,6 @@ function ThresholdChart({
 
   // Drag state (disabled unless editing)
   const [drag, setDrag] = useState(null); // 'min' | 'max' | null
-
-  // Hover state for tooltip
-  const [hoverInfo, setHoverInfo] = useState(null); // { x, y, value, time, index }
 
   // Local data: prefer last 30 minutes if we can fetch them
   const [localData, setLocalData] = useState(Array.isArray(data) ? data : []);
@@ -253,7 +246,7 @@ function ThresholdChart({
           onChange && onChange({ 
             min: dbMin, 
             max: dbMax, 
-            warning: Number.isFinite(dbWarning) ? dbWarning : Math.max(5, Math.floor((dbMax - dbMin) * 0.1))
+            warning: Number.isFinite(dbWarning) ? dbWarning : Math.floor((dbMax - dbMin) * 0.1)
           });
         }
       } catch {
@@ -270,21 +263,19 @@ function ThresholdChart({
 
   // Dynamic zoom based on limits and data - only when not editing
   const plotData = (localData && localData.length ? localData : data) || [];
-  const dataMin = plotData.length > 0 ? Math.min(...plotData) : min;
-  const dataMax = plotData.length > 0 ? Math.max(...plotData) : max;
   const limitPadding = 10; // Add padding around limits for better visibility
   
   // Use static zoom while editing, dynamic zoom when not editing
   const yMinScale = isEditing 
-    ? (editScaleMin !== null ? editScaleMin : Math.min(draftMin - limitPadding, -20)) // Use frozen scale while editing
+    ? (editScaleMin !== null ? editScaleMin : (draftMin !== null ? draftMin - limitPadding : -20)) // Use frozen scale while editing
     : plotData.length > 0 
-      ? Math.min(min - limitPadding, Math.min(...plotData) - limitPadding)
-      : min - limitPadding;
+      ? (min !== null ? Math.min(min - limitPadding, Math.min(...plotData) - limitPadding) : Math.min(...plotData) - limitPadding)
+      : (min !== null ? min - limitPadding : -20);
   const yMaxScale = isEditing 
-    ? (editScaleMax !== null ? editScaleMax : Math.max(draftMax + limitPadding, 100)) // Use frozen scale while editing
+    ? (editScaleMax !== null ? editScaleMax : (draftMax !== null ? draftMax + limitPadding : 100)) // Use frozen scale while editing
       : plotData.length > 0 
-        ? Math.max(max + limitPadding, Math.max(...plotData) + limitPadding)
-        : max + limitPadding;
+        ? (max !== null ? Math.max(max + limitPadding, Math.max(...plotData) + limitPadding) : Math.max(...plotData) + limitPadding)
+        : (max !== null ? max + limitPadding : 100);
   
   const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
   const y = (t) =>
@@ -297,16 +288,18 @@ function ThresholdChart({
     
     // Only check the latest (most recent) value for line color
     const latestValue = plotData[plotData.length - 1];
-    let lineColor = 'green';
+    let lineColor = 'green'; // Default color when no thresholds set
     
-    if (latestValue < min || latestValue > max) {
-      lineColor = 'red'; // Danger zone - latest value is in danger
-    } else if (latestValue <= min + warning || latestValue >= max - warning) {
-      lineColor = 'orange'; // Warning zone - latest value is in warning
+    if (min !== null && max !== null && warning !== null) {
+      if (latestValue < min || latestValue > max) {
+        lineColor = 'red'; // Danger zone - latest value is in danger
+      } else if (latestValue <= min + warning || latestValue >= max - warning) {
+        lineColor = 'orange'; // Warning zone - latest value is in warning
+      }
     }
-    // Otherwise stays green (latest value is in good zone)
+    // Otherwise stays green (latest value is in good zone or no thresholds set)
     
-    // Create single path for the entire line
+   // Create single path for the entire line
     let path = `M ${x(0)} ${y(plotData[0])}`;
     for (let i = 1; i < plotData.length; i++) {
       path += ` L ${x(i)} ${y(plotData[i])}`;
@@ -324,11 +317,6 @@ function ThresholdChart({
   const tickText = darkMode ? '#D1D5DB' : '#6B7280';
   const orange = '#F59E0B';
   const red = '#EF4444';
-
-  const trackX = padL + chartW + 16;
-  const trackW = 12, handleW = 18, handleH = 22, handleRX = 4;
-
-  // Warning zones are now calculated directly in the SVG rectangles
 
   // Drag logic: enabled only in edit mode
   useEffect(() => {
@@ -365,15 +353,14 @@ function ThresholdChart({
 
   // Positions for inline inputs (absolute, next to the track)
   const containerStyles = 'relative w-full max-w-4xl overflow-visible';
-  const inputRight = 8; // px from SVG right edge
   
   // Use fixed pixel positions while editing to prevent jumping
   const maxTop = isEditing 
     ? (editScaleMax !== null ? padT + chartH * (1 - (clamp(draftMax, editScaleMin, editScaleMax) - editScaleMin) / (editScaleMax - editScaleMin)) - 12 : y(draftMax) - 12)
-    : y(max) - 12;
+    : (max !== null ? y(max) - 12 : 0);
   const minTop = isEditing 
     ? (editScaleMax !== null ? padT + chartH * (1 - (clamp(draftMin, editScaleMin, editScaleMax) - editScaleMin) / (editScaleMax - editScaleMin)) - 12 : y(draftMin) - 12)
-    : y(min) - 12;
+    : (min !== null ? y(min) - 12 : 0);
 
   // Handlers
   const startEdit = () => {
@@ -384,8 +371,8 @@ function ThresholdChart({
     setDraftMax(max);
     
     // Freeze the Y-scale at current values
-    const currentYMin = Math.min(min - limitPadding, -20);
-    const currentYMax = Math.max(max + limitPadding, 100);
+    const currentYMin = min !== null ? Math.min(min - limitPadding, -20) : -20;
+    const currentYMax = max !== null ? Math.max(max + limitPadding, 100) : 100;
     setEditScaleMin(currentYMin);
     setEditScaleMax(currentYMax);
     
@@ -409,7 +396,10 @@ function ThresholdChart({
       return;
     }
     const nMin = Number(draftMin), nMax = Number(draftMax);
-    if (!(Number.isFinite(nMin) && Number.isFinite(nMax) && nMin < nMax)) return;
+    if (!(Number.isFinite(nMin) && Number.isFinite(nMax) && nMin < nMax)) {
+      setSaveStatus('error');
+      return;
+    }
 
     try {
       setSaveStatus('saving');
@@ -425,17 +415,17 @@ function ThresholdChart({
         .eq('sensor_id', sensorId);
       if (error) throw error;
 
-             // reflect in parent
-       onChange && onChange({ min: nMin, max: nMax, warning: draftWarning });
-       setOrigMin(nMin);
-       setOrigMax(nMax);
-       setOrigWarning(draftWarning);
-       // Clear frozen scale
-       setEditScaleMin(null);
-       setEditScaleMax(null);
-       setIsEditing(false);
-       setSaveStatus('saved');
-       setTimeout(() => setSaveStatus(''), 1500);
+      // reflect in parent
+      onChange && onChange({ min: nMin, max: nMax, warning: draftWarning });
+      setOrigMin(nMin);
+      setOrigMax(nMax);
+      setOrigWarning(draftWarning);
+      // Clear frozen scale
+      setEditScaleMin(null);
+      setEditScaleMax(null);
+      setIsEditing(false);
+      setSaveStatus('saved');
+      setTimeout(() => setSaveStatus(''), 1500);
     } catch (e) {
       console.error('Save limits error:', e);
       setSaveStatus('error');
@@ -445,13 +435,17 @@ function ThresholdChart({
   // Input change helpers (live-preview while editing)
   const setDraftMinClamped = (v) => {
     let val = clamp(Math.round(v), yMinScale, yMaxScale);
-    val = Math.min(val, draftMax - 1);
+    if (draftMax !== null) {
+      val = Math.min(val, draftMax - 1);
+    }
     setDraftMin(val);
     // Don't call onChange while editing - only update local draft state
   };
   const setDraftMaxClamped = (v) => {
     let val = clamp(Math.round(v), yMinScale, yMaxScale);
-    val = Math.max(val, draftMin + 1);
+    if (draftMin !== null) {
+      val = Math.max(val, draftMin + 1);
+    }
     setDraftMax(val);
     // Don't call onChange while editing - only update local draft state
   };
@@ -511,379 +505,385 @@ function ThresholdChart({
         </div>
       )}
 
-       <svg ref={svgRef} width={W} height={H} className="block">
-         <rect x={padL} y={padT} width={chartW} height={chartH} fill="#FFFFFF" stroke={strokeAxis} />
+      <svg ref={svgRef} width={W} height={H} className="block">
+        <rect x={padL} y={padT} width={chartW} height={chartH} fill="#FFFFFF" stroke={strokeAxis} />
 
-                   {/* Red & orange bands */}
-          {/* Danger zones (red) - above max and below min */}
-          <rect x={padL} y={padT} width={chartW} height={Math.max(0, y(isEditing ? draftMax : max) - padT)} fill={red} opacity="0.22" />
-          <rect x={padL} y={y(isEditing ? draftMin : min)} width={chartW} height={Math.max(0, padT + chartH - y(isEditing ? draftMin : min))} fill={red} opacity="0.22" />
-          
-          {/* Warning zones (orange) - between danger and good zones */}
-          {/* Upper warning zone - between max and max-warning */}
-          <rect 
-            x={padL} 
-            y={y(isEditing ? draftMax : max)} 
-            width={chartW} 
-            height={Math.max(0, y(isEditing ? draftMax - draftWarning : max - warning) - y(isEditing ? draftMax : max))} 
-            fill={orange} 
-            opacity="0.15" 
-            stroke={orange}
-            strokeWidth="1"
-          />
-          {/* Lower warning zone - between min and min+warning */}
-          <rect 
-            x={padL} 
-            y={y(isEditing ? draftMin + (isEditing ? draftWarning : warning) : min + warning)} 
-            width={chartW} 
-            height={Math.max(0, y(isEditing ? draftMin : min) - y(isEditing ? draftMin + (isEditing ? draftWarning : warning) : min + warning))} 
-            fill={orange} 
-            opacity="0.15" 
-            stroke={orange}
-            strokeWidth="1"
-          />
+        {/* Red & orange bands - only show if limits are set */}
+        {min !== null && max !== null && warning !== null && (
+          <>
+            {/* Danger zones (red) - above max and below min */}
+            <rect x={padL} y={padT} width={chartW} height={Math.max(0, y(isEditing ? draftMax : max) - padT)} fill={red} opacity="0.22" />
+            <rect x={padL} y={y(isEditing ? draftMin : min)} width={chartW} height={Math.max(0, padT + chartH - y(isEditing ? draftMin : min))} fill={red} opacity="0.22" />
+            
+            {/* Warning zones (orange) - between danger and good zones */}
+            {/* Upper warning zone - between max and max-warning */}
+            <rect 
+              x={padL} 
+              y={y(isEditing ? draftMax : max)} 
+              width={chartW} 
+              height={Math.max(0, y(isEditing ? draftMax - draftWarning : max - warning) - y(isEditing ? draftMax : max))} 
+              fill={orange} 
+              opacity="0.15" 
+              stroke={orange}
+              strokeWidth="1"
+            />
+            {/* Lower warning zone - between min and min+warning */}
+            <rect 
+              x={padL} 
+              y={y(isEditing ? draftMin + (isEditing ? draftWarning : warning) : min + warning)} 
+              width={chartW} 
+              height={Math.max(0, y(isEditing ? draftMin : min) - y(isEditing ? draftMin + (isEditing ? draftWarning : warning) : min + warning))} 
+              fill={orange} 
+              opacity="0.15" 
+              stroke={orange}
+              strokeWidth="1"
+            />
+          </>
+        )}
 
-         {/* Limit lines */}
-         <line x1={padL} x2={padL + chartW} y1={y(isEditing ? draftMax : max)} y2={y(isEditing ? draftMax : max)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
-         <line x1={padL} x2={padL + chartW} y1={y(isEditing ? draftMin : min)} y2={y(isEditing ? draftMin : min)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
+        {/* Limit lines - only show if limits are set */}
+        {min !== null && max !== null && (
+          <>
+            <line x1={padL} x2={padL + chartW} y1={y(isEditing ? draftMax : max)} y2={y(isEditing ? draftMax : max)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
+            <line x1={padL} x2={padL + chartW} y1={y(isEditing ? draftMin : min)} y2={y(isEditing ? draftMin : min)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
+          </>
+        )}
 
-                   {/* Y ticks - consistent while editing, dynamic when not editing */}
-          {(() => {
-            if (sensorType === 'humidity') {
-              // For humidity sensors, show percentage ticks (0-100%)
-              if (isEditing) {
-                // Use consistent percentage ticks while editing
-                const humidityTicks = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
-                return humidityTicks.map((t) => (
-                  <g key={t}>
-                    <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
-                    <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
-                      {t}%
-                    </text>
-                  </g>
-                ));
-              } else {
-                // Dynamic percentage ticks based on zoom when not editing
-                const tickStep = Math.ceil((yMaxScale - yMinScale) / 10);
-                const ticks = [];
-                for (let t = Math.ceil(yMinScale / tickStep) * tickStep; t <= yMaxScale; t += tickStep) {
-                  if (t >= yMinScale && t <= yMaxScale) {
-                    ticks.push(t);
-                  }
-                }
-                return ticks.map((t) => (
-                  <g key={t}>
-                    <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
-                    <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
-                      {Math.round(t)}%
-                    </text>
-                  </g>
-                ));
-              }
+        {/* Y ticks - consistent while editing, dynamic when not editing */}
+        {(() => {
+          if (sensorType === 'humidity') {
+            // For humidity sensors, show percentage ticks (0-100%)
+            if (isEditing) {
+              // Use consistent percentage ticks while editing
+              const humidityTicks = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+              return humidityTicks.map((t) => (
+                <g key={t}>
+                  <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
+                  <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                    {t}%
+                  </text>
+                </g>
+              ));
             } else {
-              // For temperature sensors, use existing temperature logic
-              if (isEditing) {
-                // Use consistent tick marks while editing for better UX
-                const baseTicks = userTempScale === 'C' 
-                  ? [-20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(fToC)
-                  : [-20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
-                return baseTicks.map((t) => (
-                  <g key={t}>
-                    <line x1={padL - 6} x2={padL} y1={y(userTempScale === 'C' ? cToF(t) : t)} y2={y(userTempScale === 'C' ? cToF(t) : t)} stroke={strokeAxis} />
-                    <text x={padL - 10} y={y(userTempScale === 'C' ? cToF(t) : t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
-                      {Math.round(t)}{userTempScale === 'C' ? '°C' : '°F'}
-                    </text>
-                  </g>
-                ));
-              } else {
-                // Dynamic ticks based on zoom when not editing
-                const tickStep = Math.ceil((yMaxScale - yMinScale) / 10);
-                const ticks = [];
-                for (let t = Math.ceil(yMinScale / tickStep) * tickStep; t <= yMaxScale; t += tickStep) {
-                  if (t >= yMinScale && t <= yMaxScale) {
-                    ticks.push(t);
-                  }
+              // Dynamic percentage ticks based on zoom when not editing
+              const tickStep = Math.ceil((yMaxScale - yMinScale) / 10);
+              const ticks = [];
+              for (let t = Math.ceil(yMinScale / tickStep) * tickStep; t <= yMaxScale; t += tickStep) {
+                if (t >= yMinScale && t <= yMaxScale) {
+                  ticks.push(t);
                 }
-                return ticks.map((t) => (
-                  <g key={t}>
-                    <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
-                    <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
-                      {Math.round(convertForDisplay(t, userTempScale))}{userTempScale === 'C' ? '°C' : '°F'}
-                    </text>
-                  </g>
-                ));
               }
+              return ticks.map((t) => (
+                <g key={t}>
+                  <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
+                  <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                    {Math.round(t)}%
+                  </text>
+                </g>
+              ));
             }
-          })()}
+          } else {
+            // For temperature sensors, use existing temperature logic
+            if (isEditing) {
+              // Use consistent tick marks while editing for better UX
+              const baseTicks = userTempScale === 'C' 
+                ? [-20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(fToC)
+                : [-20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+              return baseTicks.map((t) => (
+                <g key={t}>
+                  <line x1={padL - 6} x2={padL} y1={y(userTempScale === 'C' ? cToF(t) : t)} y2={y(userTempScale === 'C' ? cToF(t) : t)} stroke={strokeAxis} />
+                  <text x={padL - 10} y={y(userTempScale === 'C' ? cToF(t) : t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                    {Math.round(t)}{userTempScale === 'C' ? '°C' : '°F'}
+                  </text>
+                </g>
+              ));
+            } else {
+              // Dynamic ticks based on zoom when not editing
+              const tickStep = Math.ceil((yMaxScale - yMinScale) / 10);
+              const ticks = [];
+              for (let t = Math.ceil(yMinScale / tickStep) * tickStep; t <= yMaxScale; t += tickStep) {
+                if (t >= yMinScale && t <= yMaxScale) {
+                  ticks.push(t);
+                }
+              }
+              return ticks.map((t) => (
+                <g key={t}>
+                  <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
+                  <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                    {Math.round(convertForDisplay(t, userTempScale))}{userTempScale === 'C' ? '°C' : '°F'}
+                  </text>
+                </g>
+              ));
+            }
+          }
+        })()}
 
-                   {/* Series - colored segments */}
-          {segments.map((segment, idx) => (
-            <g key={idx}>
-              {/* Glow effect for warning and danger zones */}
-              {segment.color !== 'green' && (
-                <path 
-                  d={segment.path} 
-                  fill="none" 
-                  stroke={segment.color === 'red' ? '#DC2626' : '#EA580C'} 
-                  strokeWidth="8" 
-                  strokeLinecap="round" 
-                  opacity="0.3"
-                  filter="blur(3px)"
-                />
-              )}
-              {/* Main line */}
+        {/* Series - colored segments */}
+        {segments.map((segment, idx) => (
+          <g key={idx}>
+            {/* Glow effect for warning and danger zones */}
+            {segment.color !== 'green' && (
               <path 
                 d={segment.path} 
                 fill="none" 
-                stroke={segment.color === 'red' ? '#DC2626' : segment.color === 'orange' ? '#EA580C' : '#10B981'} 
-                strokeWidth="3" 
+                stroke={segment.color === 'red' ? '#DC2626' : '#EA580C'} 
+                strokeWidth="8" 
                 strokeLinecap="round" 
+                opacity="0.3"
+                filter="blur(3px)"
               />
+            )}
+            {/* Main line */}
+            <path 
+              d={segment.path} 
+              fill="none" 
+              stroke={segment.color === 'red' ? '#DC2626' : segment.color === 'orange' ? '#EA580C' : '#10B981'} 
+              strokeWidth="3" 
+              strokeLinecap="round" 
+            />
+          </g>
+        ))}
+        {plotData.length > 0 && (
+          <g>
+            {/* Glow effect for warning and danger zones */}
+            {(() => {
+              const temp = plotData[plotData.length - 1];
+              if (min !== null && max !== null && warning !== null) {
+                if (temp < min || temp > max) {
+                  // Danger zone - red glow
+                  return (
+                    <circle 
+                      cx={x(plotData.length - 1)} 
+                      cy={y(plotData[plotData.length - 1])} 
+                      r="12" 
+                      fill="#DC2626" 
+                      opacity="0.4"
+                      filter="blur(2px)"
+                    />
+                  );
+                } else if (temp <= min + warning || temp >= max - warning) {
+                  // Warning zone - orange glow
+                  return (
+                    <circle 
+                      cx={x(plotData.length - 1)} 
+                      cy={y(plotData[plotData.length - 1])} 
+                      r="12" 
+                      fill="#EA580C" 
+                      opacity="0.4"
+                      filter="blur(2px)"
+                    />
+                  );
+                }
+              }
+              return null;
+            })()}
+            {/* Main circle */}
+            <circle 
+              cx={x(plotData.length - 1)} 
+              cy={y(plotData[plotData.length - 1])} 
+              r="5" 
+              fill={(() => {
+                const temp = plotData[plotData.length - 1];
+                if (min !== null && max !== null && warning !== null) {
+                  if (temp < min || temp > max) return '#DC2626'; // Red for danger
+                  if (temp <= min + warning || temp >= max - warning) return '#EA580C'; // Orange for warning
+                }
+                return '#10B981'; // Green for good (default when no thresholds)
+              })()}
+            />
+          </g>
+        )}
+
+        {/* Track */}
+        <rect x={padL} y={padT} width={chartW} height={chartH} fill="transparent" />
+        <rect 
+          x={padL + chartW + 16} 
+          y={padT} 
+          width={12} 
+          height={chartH} 
+          fill="#E5E7EB" 
+          stroke="#D1D5DB" 
+          rx="2"
+          style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed' }}
+        />
+
+        {/* Handles (locked unless editing) - only show if limits are set */}
+        {min !== null && max !== null && (
+          <>
+            <g
+              transform={`translate(${padL + chartW + 16 + 12 / 2}, ${y(isEditing ? draftMax : max)})`}
+              style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed', pointerEvents: isEditing ? 'auto' : 'none' }}
+              onPointerDown={(e) => { if (!isEditing) return; e.preventDefault(); setDrag('max'); }}
+            >
+              <rect x={-9} y={-11} width={18} height={22} rx={4} fill="#FFFFFF" stroke="#9CA3AF" />
+              <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
+              <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
+              <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
             </g>
-          ))}
-         {plotData.length > 0 && (
-           <g>
-             {/* Glow effect for warning and danger zones */}
-             {(() => {
-               const temp = plotData[plotData.length - 1];
-               if (temp < min || temp > max) {
-                 // Danger zone - red glow
-                 return (
-                   <circle 
-                     cx={x(plotData.length - 1)} 
-                     cy={y(plotData[plotData.length - 1])} 
-                     r="12" 
-                     fill="#DC2626" 
-                     opacity="0.4"
-                     filter="blur(2px)"
-                   />
-                 );
-               } else if (temp <= min + warning || temp >= max - warning) {
-                 // Warning zone - orange glow
-                 return (
-                   <circle 
-                     cx={x(plotData.length - 1)} 
-                     cy={y(plotData[plotData.length - 1])} 
-                     r="12" 
-                     fill="#EA580C" 
-                     opacity="0.4"
-                     filter="blur(2px)"
-                   />
-                 );
-               }
-               return null;
-             })()}
-             {/* Main circle */}
-             <circle 
-               cx={x(plotData.length - 1)} 
-               cy={y(plotData[plotData.length - 1])} 
-               r="5" 
-               fill={(() => {
-                 const temp = plotData[plotData.length - 1];
-                 if (temp < min || temp > max) return '#DC2626'; // Red for danger
-                 if (temp <= min + warning || temp >= max - warning) return '#EA580C'; // Orange for warning
-                 return '#10B981'; // Green for good
-               })()}
-             />
-           </g>
-         )}
 
-                   {/* Track */}
-          <rect x={padL} y={padT} width={chartW} height={chartH} fill="transparent" />
-          <rect 
-            x={padL + chartW + 16} 
-            y={padT} 
-            width={12} 
-            height={chartH} 
-            fill="#E5E7EB" 
-            stroke="#D1D5DB" 
-            rx="2"
-            style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed' }}
+            <g
+              transform={`translate(${padL + chartW + 16 + 12 / 2}, ${y(isEditing ? draftMin : min)})`}
+              style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed', pointerEvents: isEditing ? 'auto' : 'none' }}
+              onPointerDown={(e) => { if (!isEditing) return; e.preventDefault(); setDrag('min'); }}
+            >
+              <rect x={-9} y={-11} width={18} height={22} rx={4} fill="#FFFFFF" stroke="#9CA3AF" />
+              <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
+              <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
+              <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
+            </g>
+          </>
+        )}
+      </svg>
+
+      {/* Input fields positioned independently to the right of the chart */}
+      <div className="absolute right-0 top-0 w-28 space-y-3">
+        {/* Max Limit Input */}
+        <div className="flex flex-col items-start">
+          <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+            Max Limit
+          </label>
+          <input
+            type="number"
+            step="1"
+            min={sensorType === 'humidity' ? yMinScale : convertForDisplay(yMinScale, userTempScale)}
+            max={sensorType === 'humidity' ? yMaxScale : convertForDisplay(yMaxScale, userTempScale)}
+            value={isEditing 
+              ? (sensorType === 'humidity' ? (draftMax ?? '') : convertForDisplay(draftMax, userTempScale) ?? '')
+              : (sensorType === 'humidity' ? (max ?? '') : convertForDisplay(max, userTempScale) ?? '')
+            }
+            disabled={!isEditing}
+            onChange={(e) => {
+              const displayVal = Number(e.target.value);
+              if (sensorType === 'humidity') {
+                setDraftMaxClamped(displayVal);
+              } else {
+                const fahrenheitVal = convertFromDisplay(displayVal, userTempScale);
+                setDraftMaxClamped(fahrenheitVal);
+              }
+            }}
+            className={baseInput}
+            title={`Max (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
           />
+        </div>
 
-         {/* Handles (locked unless editing) */}
-                   <g
-            transform={`translate(${padL + chartW + 16 + 12 / 2}, ${y(isEditing ? draftMax : max)})`}
-            style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed', pointerEvents: isEditing ? 'auto' : 'none' }}
-            onPointerDown={(e) => { if (!isEditing) return; e.preventDefault(); setDrag('max'); }}
-          >
-            <rect x={-9} y={-11} width={18} height={22} rx={4} fill="#FFFFFF" stroke="#9CA3AF" />
-            <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
-            <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
-            <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
-          </g>
+        {/* Min Limit Input */}
+        <div className="flex flex-col items-start">
+          <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+            Min Limit
+          </label>
+          <input
+            type="number"
+            step="1"
+            min={sensorType === 'humidity' ? yMinScale : convertForDisplay(yMinScale, userTempScale)}
+            max={sensorType === 'humidity' ? yMaxScale : convertForDisplay(yMaxScale, userTempScale)}
+            value={isEditing 
+              ? (sensorType === 'humidity' ? (draftMin ?? '') : convertForDisplay(draftMin, userTempScale) ?? '')
+              : (sensorType === 'humidity' ? (min ?? '') : convertForDisplay(min, userTempScale) ?? '')
+            }
+            disabled={!isEditing}
+            onChange={(e) => {
+              const displayVal = Number(e.target.value);
+              if (sensorType === 'humidity') {
+                setDraftMinClamped(displayVal);
+              } else {
+                const fahrenheitVal = convertFromDisplay(displayVal, userTempScale);
+                setDraftMinClamped(fahrenheitVal);
+              }
+            }}
+            className={baseInput}
+            title={`Min (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
+          />
+        </div>
 
-          <g
-            transform={`translate(${padL + chartW + 16 + 12 / 2}, ${y(isEditing ? draftMin : min)})`}
-            style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed', pointerEvents: isEditing ? 'auto' : 'none' }}
-            onPointerDown={(e) => { if (!isEditing) return; e.preventDefault(); setDrag('min'); }}
-          >
-            <rect x={-9} y={-11} width={18} height={22} rx={4} fill="#FFFFFF" stroke="#9CA3AF" />
-            <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
-            <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
-            <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
-          </g>
-       </svg>
+        {/* Warning Limit Input */}
+        <div className="flex flex-col items-start">
+          <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+            Warning
+          </label>
+          <input
+            type="number"
+            step="1"
+            min="0"
+            max=""
+            value={isEditing ? (draftWarning ?? '') : (warning ?? '')}
+            disabled={!isEditing}
+            onChange={(e) => {
+              const val = Math.max(0, Number(e.target.value));
+              setDraftWarning(val);
+              // Don't call onChange while editing - only update local draft state
+            }}
+            className={baseInput}
+            title={`Warning margin (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
 
-               {/* Input fields positioned independently to the right of the chart */}
-        <div className="absolute right-0 top-0 w-28 space-y-3">
-                       {/* Max Limit Input */}
-            <div className="flex flex-col items-start">
-              <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
-                Max Limit
-              </label>
-              <input
-                type="number"
-                step="1"
-                min={sensorType === 'humidity' ? yMinScale : convertForDisplay(yMinScale, userTempScale)}
-                max={sensorType === 'humidity' ? yMaxScale : convertForDisplay(yMaxScale, userTempScale)}
-                value={isEditing 
-                  ? (sensorType === 'humidity' ? draftMax : convertForDisplay(draftMax, userTempScale))
-                  : (sensorType === 'humidity' ? max : convertForDisplay(max, userTempScale))
-                }
-                disabled={!isEditing}
-                onChange={(e) => {
-                  const displayVal = Number(e.target.value);
-                  if (sensorType === 'humidity') {
-                    setDraftMaxClamped(displayVal);
-                  } else {
-                    const fahrenheitVal = convertFromDisplay(displayVal, userTempScale);
-                    setDraftMaxClamped(fahrenheitVal);
-                  }
-                }}
-                className={baseInput}
-                title={`Max (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
-              />
-            </div>
-
-            {/* Min Limit Input */}
-            <div className="flex flex-col items-start">
-              <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
-                Min Limit
-              </label>
-              <input
-                type="number"
-                step="1"
-                min={sensorType === 'humidity' ? yMinScale : convertForDisplay(yMinScale, userTempScale)}
-                max={sensorType === 'humidity' ? yMaxScale : convertForDisplay(yMaxScale, userTempScale)}
-                value={isEditing 
-                  ? (sensorType === 'humidity' ? draftMin : convertForDisplay(draftMin, userTempScale))
-                  : (sensorType === 'humidity' ? min : convertForDisplay(min, userTempScale))
-                }
-                disabled={!isEditing}
-                onChange={(e) => {
-                  const displayVal = Number(e.target.value);
-                  if (sensorType === 'humidity') {
-                    setDraftMinClamped(displayVal);
-                  } else {
-                    const fahrenheitVal = convertFromDisplay(displayVal, userTempScale);
-                    setDraftMinClamped(fahrenheitVal);
-                  }
-                }}
-                className={baseInput}
-                title={`Min (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
-              />
-            </div>
-
-            {/* Warning Limit Input */}
-            <div className="flex flex-col items-start">
-              <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
-                Warning
-              </label>
-              <input
-                type="number"
-                step="1"
-                min="1"
-                max="20"
-                value={isEditing ? draftWarning : warning}
-                disabled={!isEditing}
-                onChange={(e) => {
-                  const val = Math.max(1, Math.min(20, Number(e.target.value)));
-                  setDraftWarning(val);
-                  // Don't call onChange while editing - only update local draft state
-                }}
-                className={baseInput}
-                title={`Warning margin (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
-              />
-            </div>
-         </div>
-       </div>
-     
-   );
- }
-
-// ---------- Main Component ----------
+/* -------------------- Main Page -------------------- */
 export default function Alerts() {
-  const [currentView, setCurrentView] = useState('alerts');
-  const [selectedId, setSelectedId] = useState(null);
-  const [alertName, setAlertName] = useState('');
-  const [sensorName, setSensorName] = useState('Select a Sensor');
-  const [sendEmail, setSendEmail] = useState(false);
-  const [sendSMS, setSendSMS] = useState(true);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
   const router = useRouter();
   const { darkMode } = useDarkMode();
 
-  // User preferences for temperature scale
-  const [userTempScale, setUserTempScale] = useState('F'); // 'F' | 'C'
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
-  // State
-  const [streams, setStreams] = useState([]);       // rows for UI list
-  const [thresholds, setThresholds] = useState({}); // id -> {min,max,warning}
-  const [series, setSeries] = useState({});         // id -> number[]
+  const [currentView, setCurrentView] = useState('alerts'); // alerts | alertDetail
+  const [selectedId, setSelectedId] = useState(null);
+
+  const [userTempScale, setUserTempScale] = useState('F'); // fetched from user_preferences.temp_scale
+  const [streams, setStreams] = useState([]);               // list rows
+  const [thresholds, setThresholds] = useState({});         // id -> {min,max,warning}
+  const [series, setSeries] = useState({});                 // id -> values in °F (or % for humidity)
   const HISTORY_LEN = 120;
 
   // Sensor Settings state / modal
   const [newSensorName, setNewSensorName] = useState('');
   const [newMetric, setNewMetric] = useState('F'); // 'C' | 'F' stored in DB
   const [newSensorType, setNewSensorType] = useState('temperature'); // 'temperature' | 'humidity'
- 
+  
   const [savingSensorName, setSavingSensorName] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
 
-  const makeKey = (sensor_id) => `${sensor_id}::temperature`;
+  const makeKey = (sensor_id) => `${sensor_id}`;
 
-  // Session check and load user preferences
+  /* ----- session + user prefs (temp scale) ----- */
   useEffect(() => {
-    const checkSession = async () => {
+    const run = async () => {
       try {
-        const { data: sessionData, error } = await supabase.auth.getSession();
-        if (error) throw error;
-        if (!sessionData.session) router.push('/login');
-        
-        // Load user temperature scale preference
+        const { data: sessionData, error: sErr } = await supabase.auth.getSession();
+        if (sErr) throw sErr;
+        if (!sessionData.session) return router.push('/login');
+
         const userId = sessionData.session.user.id;
-        const { data: prefsRow } = await supabase
+        const { data: pref } = await supabase
           .from('user_preferences')
           .select('temp_scale')
           .eq('user_id', userId)
-          .single();
-        
-        if (prefsRow?.temp_scale) {
-          setUserTempScale(prefsRow.temp_scale);
-        }
-      } catch (err) {
-        console.error('Session check error:', err.message);
-        setError('Failed to verify session: ' + err.message);
+          .maybeSingle();
+
+        if (pref?.temp_scale) setUserTempScale(pref.temp_scale === 'C' ? 'C' : 'F');
+      } catch (e) {
+        console.error(e);
+        setError(e?.message || 'Failed to verify session');
         router.push('/login');
       }
     };
-    checkSession();
+    run();
   }, [router]);
 
-  // Initial load: sensors list (read sensor_name + metric + limits)
+  /* ----- initial sensors + latest readings + thresholds ----- */
   useEffect(() => {
     const load = async () => {
       try {
+        // Get sensors (units, names, types, thresholds)
         const { data: sensorRows, error: sErr } = await supabase
           .from('sensors')
-          .select('sensor_id, sensor_name, metric, latest_temp, approx_time, last_fetched_time, updated_at, min_limit, max_limit, sensor_type');
-
+          .select('sensor_id, sensor_name, metric, sensor_type, min_limit, max_limit, warning_limit');
         if (sErr) throw sErr;
 
-        // fallback latest from raw_readings_v2
-        const ids = (sensorRows || []).map(r => r.sensor_id).filter(Boolean);
+        const ids = (sensorRows || []).map((r) => r.sensor_id).filter(Boolean);
         let latestMap = new Map();
         if (ids.length) {
           const { data: latest, error: lErr } = await supabase
@@ -891,66 +891,135 @@ export default function Alerts() {
             .select('sensor_id, reading_value, timestamp, approx_time')
             .in('sensor_id', ids)
             .order('timestamp', { ascending: false });
-          if (!lErr && latest) {
-            for (const row of latest) {
-              if (!latestMap.has(row.sensor_id)) latestMap.set(row.sensor_id, row);
-            }
+          if (lErr) throw lErr;
+          for (const row of latest || []) {
+            if (!latestMap.has(row.sensor_id)) latestMap.set(row.sensor_id, row);
           }
         }
 
         const nextThresholds = {};
-        const ui = (sensorRows || []).map(r => {
-          const unit = (r.metric || 'F').toUpperCase() === 'C' ? 'C' : 'F';
+        const ui = (sensorRows || []).map((r) => {
           const key = makeKey(r.sensor_id);
-          const lr = latestMap.get(r.sensor_id);
+          const unit = (r.metric || 'F').toUpperCase(); // 'F' | 'C' | '%'
+          const sensorType = r.sensor_type || (unit === '%' ? 'humidity' : 'temperature');
+          const last = latestMap.get(r.sensor_id);
 
-          const raw = r.latest_temp ?? (lr ? Number(lr.reading_value) : null);
-          // For humidity sensors, keep raw percentage values (0-100)
-          // For temperature sensors, convert to Fahrenheit
-          const tempF = raw != null 
-            ? (r.sensor_type === 'humidity' ? Number(raw) : toF(raw, unit))
-            : null;
+          const rawVal = last ? Number(last.reading_value) : null;
+          const valF = sensorType === 'humidity' ? rawVal : (rawVal != null ? toF(rawVal, unit === 'C' ? 'C' : 'F') : null);
 
-          const lastIso =
-            r.approx_time ||
-            r.last_fetched_time ||
-            r.updated_at ||
-            (lr ? (lr.approx_time ||
-              new Date((Number(lr.timestamp) > 1e12 ? Number(lr.timestamp) : Number(lr.timestamp) * 1000)).toISOString()
-            ) : null);
-
-                     const th = {
-             min: Number.isFinite(r?.min_limit) ? Number(r.min_limit) : 20,
-             max: Number.isFinite(r?.max_limit) ? Number(r.max_limit) : 60,
-             warning: Number.isFinite(r?.warning_limit) ? Number(r.warning_limit) : 5,
-           };
+          const th = {
+            min: Number.isFinite(r?.min_limit) ? Number(r.min_limit) : null,
+            max: Number.isFinite(r?.max_limit) ? Number(r.max_limit) : null,
+            warning: Number.isFinite(r?.warning_limit) ? Number(r.warning_limit) : 0,
+          };
           nextThresholds[key] = th;
 
           return {
             id: key,
             name: r.sensor_name || r.sensor_id,
-            temp: tempF,
-            status: computeStatus(tempF, th),
-            lastReading: lastIso ? new Date(lastIso).toLocaleString() : 'No readings yet',
+            temp: valF,
+            status: computeStatus(valF, th),
+            lastReading: last ? toLocalFromReading(last) : '—',
             sensor_id: r.sensor_id,
-            unit,     // stored unit (C or F)
-            metric: 'F', // displayed unit is always F
-            sensor_type: r.sensor_type || 'temperature', // 'temperature' | 'humidity'
+            unit,
+            sensor_type: sensorType,
           };
         });
 
         setThresholds(nextThresholds);
         setStreams(ui.sort((a, b) => a.name.localeCompare(b.name)));
-      } catch (err) {
-        console.error('Load error:', err);
-        setError('Failed to load data: ' + (err?.message || err));
+      } catch (e) {
+        console.error(e);
+        setError(e?.message || 'Failed to load sensors');
       } finally {
         setLoading(false);
       }
     };
-
     load();
   }, []);
+
+  /* ----- history after selecting a sensor ----- */
+  useEffect(() => {
+    if (!selectedId) return;
+    const sel = streams.find((s) => s.id === selectedId);
+    if (!sel) return;
+    if (series[selectedId]) return;
+
+    const loadHistory = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('raw_readings_v2')
+          .select('reading_value, timestamp, approx_time')
+          .eq('sensor_id', sel.sensor_id)
+          .order('timestamp', { ascending: true })
+          .limit(HISTORY_LEN);
+        if (error) throw error;
+
+        const values = (data || []).map((r) =>
+          sel.sensor_type === 'humidity' ? Number(r.reading_value) : toF(Number(r.reading_value), sel.unit === 'C' ? 'C' : 'F')
+        );
+        setSeries((prev) => ({ ...prev, [selectedId]: values }));
+      } catch (e) {
+        console.error(e);
+        setError(e?.message || 'Failed to load history');
+        setSeries((prev) => ({ ...prev, [selectedId]: [] }));
+      }
+    };
+    loadHistory();
+  }, [selectedId, streams, series]);
+
+  /* ----- realtime inserts ----- */
+  useEffect(() => {
+    const ch = supabase
+      .channel('raw-readings-v2-all')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'raw_readings_v2' }, (payload) => {
+        const r = payload.new || {};
+        if (!r.sensor_id || (typeof r.reading_value !== 'number' && typeof r.reading_value !== 'string')) return;
+
+        setStreams((prev) => {
+          const idx = prev.findIndex((p) => p.sensor_id === r.sensor_id);
+          if (idx === -1) return prev;
+          const unit = prev[idx].unit;
+          const type = prev[idx].sensor_type;
+          const valF = type === 'humidity' ? Number(r.reading_value) : toF(Number(r.reading_value), unit === 'C' ? 'C' : 'F');
+
+          const key = prev[idx].id;
+          const th = thresholds[key] || {};
+          const next = [...prev];
+          next[idx] = {
+            ...prev[idx],
+            temp: valF,
+            status: computeStatus(valF, th),
+            lastReading: toLocalFromReading(r),
+          };
+          return next;
+        });
+
+        setSeries((prev) => {
+          const s = streams.find((p) => p.sensor_id === r.sensor_id);
+          if (!s) return prev;
+          const val = s.sensor_type === 'humidity' ? Number(r.reading_value) : toF(Number(r.reading_value), s.unit === 'C' ? 'C' : 'F');
+          const arr = prev[s.id] ? [...prev[s.id], val] : [val];
+          return { ...prev, [s.id]: arr.slice(-HISTORY_LEN) };
+        });
+      })
+      .subscribe((status) => console.log('Realtime status:', status));
+    return () => supabase.removeChannel(ch);
+  }, [thresholds, streams]);
+
+  /* ----- local helpers ----- */
+  const updateThresholdLocal = (sensorId, next) => {
+    const key = makeKey(sensorId);
+    setThresholds((prev) => {
+      const merged = { ...prev, [key]: { ...prev[key], ...next } };
+      setStreams((prevS) =>
+        prevS.map((s) =>
+          s.id === key ? { ...s, status: computeStatus(s.temp, merged[key]) } : s
+        )
+      );
+      return merged;
+    });
+  };
 
   // Keep modal fields synced to selected sensor
   useEffect(() => {
@@ -961,174 +1030,6 @@ export default function Alerts() {
     // Auto-set sensor type based on metric
     setNewSensorType(metric === '%' ? 'humidity' : 'temperature');
   }, [selectedId, streams]);
-
-  // Load history when opening detail
-  useEffect(() => {
-    if (!supabase || !selectedId || loading) return;
-    const sel = streams.find((s) => s.id === selectedId);
-    if (!sel) return;
-
-    const loadHistory = async () => {
-      try {
-        const { data, error } = await supabase
-          .from('raw_readings_v2')
-          .select('reading_value, timestamp, approx_time')
-          .eq('sensor_id', sel.sensor_id)
-          .order('timestamp', { ascending: true })
-          .limit(HISTORY_LEN);
-
-        if (error) throw error;
-
-        const unit = sel.unit || 'F';
-        // For humidity sensors, keep raw percentage values
-        // For temperature sensors, convert to Fahrenheit
-        const values = (data || []).map((d) => 
-          sel.sensor_type === 'humidity' ? Number(d.reading_value) : toF(d.reading_value, unit)
-        );
-        setSeries((prev) => ({
-          ...prev,
-          [selectedId]: values.length > 0 ? values : [sel.temp ?? 42],
-        }));
-      } catch (err) {
-        console.error('History load error:', err);
-        setError('Failed to load history: ' + err.message);
-        setSeries((prev) => ({
-          ...prev,
-          [selectedId]: [42, 43, 41, 44, 40],
-        }));
-      }
-    };
-
-    if (!series[selectedId]) loadHistory();
-  }, [selectedId, streams, loading, series]);
-
-  // Realtime Updates (raw_readings_v2) -> always convert to F using stored unit
-  useEffect(() => {
-    if (!supabase || loading) return;
-
-    const onInsert = (payload) => {
-      const r = payload.new || {};
-      if (!r.sensor_id || (typeof r.reading_value !== 'number' && typeof r.reading_value !== 'string')) return;
-
-      setStreams((prev) => {
-        const idx = prev.findIndex((p) => p.sensor_id === r.sensor_id);
-        const unit = idx !== -1 ? prev[idx].unit : 'F';
-        const sensorType = idx !== -1 ? prev[idx].sensor_type : 'temperature';
-        // For humidity sensors, keep raw percentage values
-        // For temperature sensors, convert to Fahrenheit
-        const tempValF = sensorType === 'humidity' 
-          ? Number(r.reading_value) 
-          : toF(Number(r.reading_value), unit);
-        const id = idx !== -1 ? prev[idx].id : makeKey(r.sensor_id);
-        const th = thresholds[id] || { min: 20, max: 60 }; // fallback only if not loaded yet
-        const name = idx !== -1 ? prev[idx].name : r.sensor_id;
-
-        const row = {
-          id,
-          name,
-          temp: tempValF,
-          status: computeStatus(tempValF, th),
-          lastReading: toLocalFromReading(r),
-          sensor_id: r.sensor_id,
-          unit,
-          metric: 'F',
-        };
-
-        if (idx === -1) return [...prev, row].sort((a, b) => a.name.localeCompare(b.name));
-        const next = [...prev];
-        next[idx] = row;
-        return next.sort((a, b) => a.name.localeCompare(b.name));
-      });
-
-      setSeries((prev) => {
-        const id = makeKey(r.sensor_id);
-        const existing = streams.find((p) => p.sensor_id === r.sensor_id);
-        const unit = existing?.unit || 'F';
-        const sensorType = existing?.sensor_type || 'temperature';
-        // For humidity sensors, keep raw percentage values
-        // For temperature sensors, convert to Fahrenheit
-        const nextVal = sensorType === 'humidity' 
-          ? Number(r.reading_value) 
-          : toF(Number(r.reading_value), unit);
-        const arr = prev[id] ? [...prev[id], nextVal] : [nextVal];
-        return { ...prev, [id]: arr.slice(-HISTORY_LEN) };
-      });
-    };
-
-    const ch = supabase
-      .channel('raw-readings-v2-all')
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'raw_readings_v2' }, onInsert)
-      .subscribe((status) => {
-        console.log('Subscription status:', status);
-      });
-
-    return () => {
-      supabase.removeChannel(ch);
-    };
-  }, [thresholds, loading, streams]);
-
-  // Refresh one sensor's latest + history using a given unit
-  const refreshOneSensor = async (sensor_id, unit) => {
-    try {
-      const key = makeKey(sensor_id);
-
-      // latest
-      const { data: latest, error: lErr } = await supabase
-        .from('raw_readings_v2')
-        .select('reading_value, timestamp, approx_time')
-        .eq('sensor_id', sensor_id)
-        .order('timestamp', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      if (lErr) throw lErr;
-
-      // Find the sensor to get its type
-      const sensor = streams.find(s => s.sensor_id === sensor_id);
-      const sensorType = sensor?.sensor_type || 'temperature';
-      
-      // For humidity sensors, keep raw percentage values
-      // For temperature sensors, convert to Fahrenheit
-      const latestTempF = latest 
-        ? (sensorType === 'humidity' ? Number(latest.reading_value) : toF(latest.reading_value, unit))
-        : null;
-      const lastTime = latest ? toLocalFromReading(latest) : 'No readings yet';
-
-      setStreams((prev) =>
-        prev
-          .map((row) =>
-            row.sensor_id === sensor_id
-              ? {
-                  ...row,
-                  temp: latestTempF,
-                  lastReading: lastTime,
-                  unit,      // update stored unit
-                  metric: 'F'
-                }
-              : row
-          )
-          .sort((a, b) => a.name.localeCompare(b.name))
-      );
-
-      // history
-      const { data: hist, error: hErr } = await supabase
-        .from('raw_readings_v2')
-        .select('reading_value, timestamp')
-        .eq('sensor_id', sensor_id)
-        .order('timestamp', { ascending: true })
-        .limit(HISTORY_LEN);
-
-      if (!hErr && hist) {
-        // For humidity sensors, keep raw percentage values
-        // For temperature sensors, convert to Fahrenheit
-        const values = hist.map((d) => 
-          sensorType === 'humidity' ? Number(d.reading_value) : toF(d.reading_value, unit)
-        );
-        setSeries((prev) => ({ ...prev, [key]: values }));
-      }
-    } catch (e) {
-      console.error('refreshOneSensor error:', e);
-    }
-  };
 
   // Save sensor settings (name + metric)
   const saveSensorName = async () => {
@@ -1191,9 +1092,6 @@ export default function Alerts() {
           .sort((a, b) => a.name.localeCompare(b.name))
       );
 
-      // Re-fetch latest + history to apply conversion with new unit
-      await refreshOneSensor(sel.sensor_id, dbUnit);
-
       setShowSettings(false);
       setError('');
     } catch (e) {
@@ -1204,35 +1102,11 @@ export default function Alerts() {
     }
   };
 
-  // Handlers
   const handleAlertClick = (item) => {
     setSelectedId(item.id);
     setCurrentView('alertDetail');
   };
 
-  const handleBack = () => {
-    setCurrentView('alerts');
-    setSelectedId(null);
-  };
-
-  // Update thresholds in state (used by list statuses and detail header)
-  const updateThreshold = async (displayName, next) => {
-    const item = streams.find((s) => s.name === displayName);
-    if (!item) return;
-    const key = item.id;
-
-    setThresholds((prev) => {
-      const updated = { ...prev, [key]: next };
-      setStreams((prevS) =>
-        prevS
-          .map((s) => (s.id === key ? { ...s, status: computeStatus(s.temp, next) } : s))
-          .sort((a, b) => a.name.localeCompare(b.name))
-      );
-      return updated;
-    });
-  };
-
-  // UI bits
   const SectionHeader = ({ icon, label, status }) => {
     const { section } = getStatusStyles(status, darkMode);
     return (
@@ -1244,6 +1118,9 @@ export default function Alerts() {
 
   const AlertCard = ({ sensor }) => {
     const { value } = getStatusStyles(sensor.status, darkMode);
+    const display = sensor.sensor_type === 'humidity'
+      ? (sensor.temp != null ? `${sensor.temp.toFixed(1)}%` : '—')
+      : (sensor.temp != null ? `${convertForDisplay(sensor.temp, userTempScale).toFixed(1)}°${userTempScale}` : '—');
     return (
       <div
         className={`rounded-lg shadow p-4 border-l-4 ${cardClass(sensor.status, darkMode)} cursor-pointer hover:shadow-lg transition-shadow`}
@@ -1258,13 +1135,7 @@ export default function Alerts() {
             </p>
           </div>
           <div className="text-right">
-            <div className={`${value} text-xl mb-1 font-bold`}>
-              {sensor.sensor_type === 'humidity' ? (
-                '💧 ' + (sensor.temp != null && !Number.isNaN(sensor.temp) ? sensor.temp.toFixed(1) : '--') + '%'
-              ) : (
-                '🌡️ ' + (sensor.temp != null && !Number.isNaN(sensor.temp) ? convertForDisplay(sensor.temp, userTempScale).toFixed(1) : '--') + (userTempScale === 'C' ? '°C' : '°F')
-              )}
-            </div>
+            <div className={`${value} text-xl mb-1 font-bold`}>{sensor.sensor_type === 'humidity' ? `💧 ${display}` : `🌡️ ${display}`}</div>
           </div>
         </div>
       </div>
@@ -1279,7 +1150,7 @@ export default function Alerts() {
           <main className="flex-1 p-6 flex items-center justify-center">
             <div className="text-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-500 mx-auto mb-4"></div>
-              <p>Loading alerts data...</p>
+              <p>Loading…</p>
             </div>
           </main>
         </div>
@@ -1287,7 +1158,7 @@ export default function Alerts() {
     );
   }
 
-  // Views
+  /* -------------------- Views -------------------- */
   const renderAlertsView = () => (
     <main className="flex-1 p-6">
       <div className="flex justify-between items-center mb-6">
@@ -1351,20 +1222,16 @@ export default function Alerts() {
           )}
         </div>
 
-        <div className={`${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-600'} p-3 rounded flex items-center`}>
-          <span className="mr-3 text-xl">🛠️</span> System Alerts
-        </div>
-        <div className={`col-span-full p-4 text-center ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-          No system alerts at this time
-        </div>
-
-        <div className="flex justify-end mt-8">
-          <button
-            className={`px-6 py-3 rounded-lg font-semibold text-white border ${darkMode ? 'bg-orange-700 hover:bg-orange-800 border-orange-700' : 'bg-orange-500 hover:bg-orange-600 border-orange-500'}`}
-            onClick={() => setCurrentView('addAlert')}
-          >
-            Add Alert
-          </button>
+        <SectionHeader icon="🧩" label="Unconfigured" status="Unconfigured" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {streams.filter((s) => s.status === 'Unconfigured').map((s) => (
+            <AlertCard key={`u-${s.id}`} sensor={s} />
+          ))}
+          {streams.filter((s) => s.status === 'Unconfigured').length === 0 && (
+            <div className={`col-span-full p-4 text-center ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              All sensors have limits configured
+            </div>
+          )}
         </div>
       </div>
     </main>
@@ -1373,16 +1240,17 @@ export default function Alerts() {
   const renderAlertDetailView = () => {
     const selected = streams.find((s) => s.id === selectedId);
     if (!selected) return null;
-    const t = thresholds[selected.id] || { min: 20, max: 60 };
-    const data = series[selected.id] || (selected.temp != null ? [selected.temp] : []);
+    const t = thresholds[selected.id] || {};
+    const data = series[selected.id] || [];
+
+
 
     return (
       <main className="flex-1 p-6">
-        {/* TOP BAR with Back */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-3">
             <button
-              onClick={handleBack}
+              onClick={() => { setCurrentView('alerts'); setSelectedId(null); }}
               className={`px-3 py-2 rounded border ${darkMode ? 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600' : 'bg-white text-gray-800 border-gray-300 hover:bg-gray-100'}`}
             >
               ← Back
@@ -1411,13 +1279,13 @@ export default function Alerts() {
         </div>
 
         <div className="space-y-6">
-          <SectionHeader
-            icon={selected.status === 'Needs Attention' ? '🚨' : selected.status === 'Warning' ? '⚠️' : '✅'}
-            label={selected.status}
-            status={selected.status}
-          />
+          <div className={`${getStatusStyles(selected.status, darkMode).section} p-3 rounded flex items-center`}>
+            <span className="mr-3 text-xl">
+              {selected.status === 'Needs Attention' ? '🚨' : selected.status === 'Warning' ? '⚠️' : selected.status === 'Good' ? '✅' : '🧩'}
+            </span>
+            {selected.status}
+          </div>
 
-          {/* INFO CARD with temperature + Settings button */}
           <div className={`rounded-lg shadow p-4 border-l-4 ${getStatusStyles(selected.status, darkMode).border} ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
             <div className="flex justify-between items-center">
               <div>
@@ -1428,11 +1296,9 @@ export default function Alerts() {
               </div>
               <div className="flex items-center gap-3">
                 <div className={`${getStatusStyles(selected.status, darkMode).value} text-xl mb-1 font-bold`}>
-                  {selected.sensor_type === 'humidity' ? (
-                    '💧 ' + (selected.temp != null ? selected.temp.toFixed(1) : '--') + '%'
-                  ) : (
-                    '🌡️ ' + (selected.temp != null ? convertForDisplay(selected.temp, userTempScale).toFixed(1) : '--') + (userTempScale === 'C' ? '°C' : '°F')
-                  )}
+                  {selected.sensor_type === 'humidity'
+                    ? `💧 ${selected.temp != null ? selected.temp.toFixed(1) : '—'}%`
+                    : `🌡️ ${selected.temp != null ? convertForDisplay(selected.temp, userTempScale).toFixed(1) : '—'}°${userTempScale}`}
                 </div>
                 <button
                   onClick={() => { 
@@ -1451,6 +1317,77 @@ export default function Alerts() {
                 >
                   ⚙️ Settings
                 </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Chart */}
+          <div className={`rounded-lg shadow p-6 border-2 border-blue-400 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
+            <div className="flex justify-between items-center mb-4">
+              <div>
+                <h3 className="text-lg font-semibold">
+                  {selected.sensor_type === 'humidity' ? 'Humidity History' : 'Temperature History'}
+                </h3>
+                <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                  {selected.name} • {selected.sensor_type === 'humidity' ? '%' : 'F'}
+                </p>
+              </div>
+              <div className="text-sm">
+                {t.min !== null && t.max !== null ? (
+                  <>Limits: <strong>{t.min}{selected.sensor_type === 'humidity' ? '%' : '°F'}</strong> – <strong>{t.max}{selected.sensor_type === 'humidity' ? '%' : '°F'}</strong></>
+                ) : (
+                  <>No limits set</>
+                )}
+              </div>
+            </div>
+
+            <div className="flex justify-start">
+              <ThresholdChart
+                data={data}
+                min={t.min}
+                max={t.max}
+                warning={t.warning}
+                darkMode={darkMode}
+                onChange={({ min, max, warning }) => updateThresholdLocal(selected.sensor_id, { min, max, warning })}
+                sensorId={selected.sensor_id}
+                unit={selected.unit}
+                editable
+                userTempScale={userTempScale}
+                sensorType={selected.sensor_type}
+              />
+            </div>
+          </div>
+
+          <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
+            <h3 className="text-lg font-semibold mb-4">Last Reading</h3>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span>Time</span>
+                <span className="font-medium">{selected.lastReading}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Threshold</span>
+                <span className="font-medium">
+                  {Number.isFinite(t.min) && Number.isFinite(t.max)
+                    ? (selected.sensor_type === 'humidity'
+                      ? `${t.min}% - ${t.max}%`
+                      : `${convertForDisplay(t.min, userTempScale).toFixed(0)}°${userTempScale} - ${convertForDisplay(t.max, userTempScale).toFixed(0)}°${userTempScale}`)
+                    : 'Not set'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span>{selected.sensor_type === 'humidity' ? 'Humidity' : 'Air Temperature'}</span>
+                <span className="font-medium">
+                  {selected.temp != null
+                    ? (selected.sensor_type === 'humidity'
+                      ? `${selected.temp.toFixed(1)}%`
+                      : `${convertForDisplay(selected.temp, userTempScale).toFixed(1)}°${userTempScale}`)
+                    : '—'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span>Sensor ID</span>
+                <span className="font-medium font-mono text-sm">{selected.sensor_id}</span>
               </div>
             </div>
           </div>
@@ -1556,218 +1493,18 @@ export default function Alerts() {
               </div>
             </div>
           )}
-
-                     <div className={`rounded-lg shadow p-6 border-2 border-blue-400 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-             <div className="flex justify-between items-center mb-4">
-               <div>
-                 <h3 className="text-lg font-semibold">
-                   {selected.sensor_type === 'humidity' ? 'Humidity History' : 'Temperature History'}
-                 </h3>
-                 <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-                   {selected.name} • {selected.sensor_type === 'humidity' ? '%' : 'F'}
-                 </p>
-               </div>
-               <div className="text-sm">
-                 Limits: <strong>{t.min}{selected.sensor_type === 'humidity' ? '%' : '°F'}</strong> – <strong>{t.max}{selected.sensor_type === 'humidity' ? '%' : '°F'}</strong>
-               </div>
-             </div>
-
-                         <div className="flex justify-start">
-                              <ThresholdChart
-                  data={data}
-                  min={t.min}
-                  max={t.max}
-                  warning={t.warning}
-                  darkMode={darkMode}
-                  onChange={({ min, max, warning }) => updateThreshold(selected.name, { min, max, warning })}
-                  sensorId={selected.sensor_id}
-                  unit={selected.unit}
-                  editable
-                  userTempScale={userTempScale}
-                  sensorType={selected.sensor_type}
-                />
-             </div>
-          </div>
-
-          <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-            <h3 className="text-lg font-semibold mb-4">Last Reading</h3>
-            <div className="space-y-3">
-              <div className="flex justify-between">
-                <span>Time</span>
-                <span className="font-medium">{selected.lastReading}</span>
-              </div>
-                             <div className="flex justify-between">
-                 <span>Threshold</span>
-                 <span className="font-medium">
-                   {t.min}{selected.sensor_type === 'humidity' ? '%' : '°F'} - {t.max}{selected.sensor_type === 'humidity' ? '%' : '°F'}
-                 </span>
-               </div>
-               <div className="flex justify-between">
-                 <span>{selected.sensor_type === 'humidity' ? 'Humidity' : 'Air Temperature'}</span>
-                 <span className="font-medium">
-                   {selected.temp != null ? selected.temp.toFixed(1) : '--'}{selected.sensor_type === 'humidity' ? '%' : '°F'}
-                 </span>
-               </div>
-               <div className="flex justify-between">
-                 <span>Displayed Unit</span>
-                 <span className="font-medium">
-                   {selected.sensor_type === 'humidity' ? 'Percentage (%)' : 'Fahrenheit (°F)'}
-                 </span>
-               </div>
-              <div className="flex justify-between">
-                <span>Sensor ID</span>
-                <span className="font-medium font-mono text-sm">{selected.sensor_id}</span>
-              </div>
-            </div>
-          </div>
         </div>
       </main>
     );
   };
 
-  const renderAddAlertView = () => (
-    <main className="flex-1 p-6">
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-3xl font-bold">Add Alert</h2>
-        <div className="flex items-center space-x-4">
-          <button
-            onClick={async () => {
-              try {
-                const { error } = await supabase.auth.signOut();
-                if (error) throw error;
-                router.push('/login');
-              } catch (err) {
-                setError('Failed to sign out: ' + err.message);
-              }
-            }}
-            className={`px-4 py-2 rounded ${darkMode ? 'bg-red-700 text-white hover:bg-red-800' : 'bg-red-500 text-white hover:bg-red-600'}`}
-          >
-            Log out
-          </button>
-          <div className={`w-10 h-10 ${darkMode ? 'bg-amber-700' : 'bg-amber-600'} rounded-full flex items-center justify-center text-white text-sm font-bold`}>
-            FA
-          </div>
-        </div>
-      </div>
-
-      <div className="space-y-6">
-        <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-          <h3 className="text-xl font-semibold mb-2">Create New Alert</h3>
-          <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'} mb-6`}>
-            Set up alerts for your streams to receive notifications.
-          </p>
-
-          <div className="mb-6">
-            <label className="block text-sm font-medium mb-2">Alert Name:</label>
-            <input
-              type="text"
-              value={alertName}
-              onChange={(e) => setAlertName(e.target.value)}
-              className={`border rounded px-3 py-2 w-full ${darkMode ? 'bg-gray-700 text-white border-gray-600 focus:border-orange-500' : 'bg-white border-gray-300 focus:border-orange-500'} focus:outline-none focus:ring-2 focus:ring-orange-500/20`}
-              placeholder="Enter alert name"
-            />
-          </div>
-        </div>
-
-        <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-          <h4 className="text-lg font-semibold mb-2">Trigger</h4>
-                     <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'} mb-6`}>
-             Drag the side handles to set minimum and maximum temperature limits. Warning zone is configurable and will never overlap with the danger zone.
-           </p>
-
-                     <div className="flex justify-center">
-             {/* Demo chart in Add Alert left unchanged */}
-                                                    <ThresholdChart data={[32, 33, 31, 34, 30, 29]} min={25} max={40} warning={3} darkMode={darkMode} userTempScale={userTempScale} sensorType="temperature" />
-           </div>
-        </div>
-
-        <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-          <h4 className="text-lg font-semibold mb-2">Choose Stream</h4>
-          <div className="mb-4">
-            <label className="block text-sm font-medium mb-2">Stream</label>
-            <select
-              value={sensorName}
-              onChange={(e) => setSensorName(e.target.value)}
-              className={`border rounded px-3 py-2 w-full ${darkMode ? 'bg-gray-700 text-white border-gray-600 focus:border-orange-500' : 'bg-white border-gray-300 focus:border-orange-500'} focus:outline-none focus:ring-2 focus:ring-orange-500/20`}
-            >
-              <option>Select a Stream</option>
-              {streams.map((s) => (
-                <option key={s.id} value={`${s.name} • ${s.metric}`}>
-                  {`${s.name} • ${s.metric}`}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-          <h4 className="text-lg font-semibold mb-4">Notification Settings</h4>
-          <div className="space-y-4">
-            <div className="flex items-center">
-              <input
-                type="checkbox"
-                id="sendEmail"
-                checked={sendEmail}
-                onChange={(e) => setSendEmail(e.target.checked)}
-                className="mr-3 h-4 w-4 text-orange-600 focus:ring-orange-500 border-gray-300 rounded"
-              />
-              <label htmlFor="sendEmail" className="text-sm font-medium">Send Email Notifications</label>
-            </div>
-            <div className="flex items-center">
-              <input
-                type="checkbox"
-                id="sendSMS"
-                checked={sendSMS}
-                onChange={(e) => setSendSMS(e.target.checked)}
-                className="mr-3 h-4 w-4 text-orange-600 focus:ring-orange-500 border-gray-300 rounded"
-              />
-              <label htmlFor="sendSMS" className="text-sm font-medium">Send SMS Notifications</label>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex justify-between items-center pt-6">
-          <button
-            className={`px-6 py-3 rounded-lg ${darkMode ? 'bg-gray-600 text-white hover:bg-gray-700' : 'bg-gray-300 text-gray-800 hover:bg-gray-400'}`}
-            onClick={() => setCurrentView('alerts')}
-          >
-            Cancel
-          </button>
-          <button
-            className={`px-6 py-3 rounded-lg font-semibold text-white border ${darkMode ? 'bg-orange-700 hover:bg-orange-800 border-orange-700' : 'bg-orange-500 hover:bg-orange-600 border-orange-500'}`}
-            onClick={async () => {
-              try {
-                const selectedStream = streams.find((s) => `${s.name} • ${s.metric}` === sensorName);
-                if (!selectedStream) {
-                  setError('Please select a valid stream');
-                  return;
-                }
-                console.log('Creating alert:', { alertName, sensorName, sendEmail, sendSMS });
-                setCurrentView('alerts');
-                setAlertName('');
-                setSensorName('Select a Sensor');
-                setSendEmail(false);
-                setSendSMS(true);
-              } catch (err) {
-                setError('Failed to create alert: ' + err.message);
-              }
-            }}
-          >
-            Create Alert
-          </button>
-        </div>
-      </div>
-    </main>
-  );
-
-  // Main Render
+  /* -------------------- Render -------------------- */
   return (
     <ErrorBoundary darkMode={darkMode}>
       <div className={`flex min-h-screen ${darkMode ? 'bg-gray-800 text-white' : 'bg-gray-100 text-gray-800'}`}>
         <Sidebar darkMode={darkMode} activeKey="alerts" />
         {currentView === 'alerts' && renderAlertsView()}
         {currentView === 'alertDetail' && renderAlertDetailView()}
-        {currentView === 'addAlert' && renderAddAlertView()}
       </div>
     </ErrorBoundary>
   );

--- a/src/app/alerts/page.js
+++ b/src/app/alerts/page.js
@@ -44,32 +44,30 @@ class ErrorBoundary extends Component {
   }
 }
 
-const DEFAULT_WARNING = { min: 20, max: 60 };
-
 // ---------- Styles ----------
 const getStatusStyles = (status, darkMode) => {
   switch (status) {
     case 'Needs Attention':
       return {
-        section: `${darkMode ? 'bg-red-900 text-red-300' : 'bg-red-100 text-red-800'}`,
+        section: `${darkMode ? 'bg-red-900 text-red-300' : 'bg-red-200 text-red-900'}`,
         border: 'border-red-500',
         value: 'text-red-600',
       };
     case 'Warning':
       return {
-        section: `${darkMode ? 'bg-yellow-900 text-yellow-300' : 'bg-yellow-100 text-yellow-800'}`,
+        section: `${darkMode ? 'bg-yellow-900 text-yellow-300' : 'bg-yellow-200 text-yellow-900'}`,
         border: 'border-yellow-400',
         value: 'text-yellow-600',
       };
     case 'Good':
       return {
-        section: `${darkMode ? 'bg-green-900 text-green-300' : 'bg-green-100 text-green-800'}`,
+        section: `${darkMode ? 'bg-green-900 text-green-300' : 'bg-green-200 text-green-900'}`,
         border: 'border-green-500',
         value: 'text-green-600',
       };
     default:
       return {
-        section: `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-700'}`,
+        section: `${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-200 text-gray-800'}`,
         border: 'border-gray-400',
         value: 'text-gray-500',
       };
@@ -96,12 +94,11 @@ const cardClass = (status, darkMode) =>
   (darkMode ? 'bg-gray-800 border-gray-500 text-white' : 'bg-white border-gray-300 text-gray-800');
 
 // ---------- Helpers ----------
-const WARNING_MARGIN = 5;
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
-const computeStatus = (temp, { min, max }) => {
+const computeStatus = (temp, { min, max, warning = 5 }) => {
   if (temp == null) return 'Good';
   if (temp < min || temp > max) return 'Needs Attention';
-  if (temp <= min + WARNING_MARGIN || temp >= max - WARNING_MARGIN) return 'Warning';
+  if (temp <= min + warning || temp >= max - warning) return 'Warning';
   return 'Good';
 };
 
@@ -118,30 +115,210 @@ const toLocalFromReading = (r) => {
 };
 
 const cToF = (c) => (c * 9) / 5 + 32;
+const fToC = (f) => (f - 32) * 5 / 9;
 const toF = (val, unit) => (val == null ? null : unit === 'C' ? cToF(Number(val)) : Number(val));
 
-// ---------- Chart ----------
-function ThresholdChart({ data, min, max, darkMode, onChange }) {
-  const svgRef = useRef(null);
-  const [drag, setDrag] = useState(null);
+// Convert temperature for display based on user preference
+const convertForDisplay = (tempF, userScale) => {
+  if (tempF == null) return null;
+  return userScale === 'C' ? fToC(tempF) : tempF;
+};
 
+// Convert display temperature back to Fahrenheit for storage
+const convertFromDisplay = (displayTemp, userScale) => {
+  if (displayTemp == null) return null;
+  return userScale === 'C' ? cToF(displayTemp) : displayTemp;
+};
+
+// ---------- Chart ----------
+function ThresholdChart({
+  data,
+  min,
+  max,
+  warning = 5, // Default warning margin
+  darkMode,
+  onChange,
+  // Alert Detail extras:
+  sensorId,   // to fetch last 30 min + update DB
+  unit,       // 'C' | 'F' (display is °F; limits stored as °F)
+  editable,   // enables "Edit limits" UX in Alert Detail
+  userTempScale = 'F', // User's preferred temperature scale
+  sensorType = 'temperature', // 'temperature' | 'humidity'
+}) {
+  const svgRef = useRef(null);
+  const containerRef = useRef(null);
+
+  // Lock / edit state
+  const [isEditing, setIsEditing] = useState(false);
+  const [saveStatus, setSaveStatus] = useState(''); // '', 'saving', 'saved', 'error'
+
+  // Draft values (used while editing)
+  const [draftMin, setDraftMin] = useState(min);
+  const [draftMax, setDraftMax] = useState(max);
+  const [draftWarning, setDraftWarning] = useState(warning);
+  const [origMin, setOrigMin] = useState(min);
+  const [origMax, setOrigMax] = useState(max);
+  const [origWarning, setOrigWarning] = useState(warning);
+
+  // freeze the y-scale while editing
+  const [editScaleMin, setEditScaleMin] = useState(null);
+  const [editScaleMax, setEditScaleMax] = useState(null);
+
+  // Drag state (disabled unless editing)
+  const [drag, setDrag] = useState(null); // 'min' | 'max' | null
+
+  // Hover state for tooltip
+  const [hoverInfo, setHoverInfo] = useState(null); // { x, y, value, time, index }
+
+  // Local data: prefer last 30 minutes if we can fetch them
+  const [localData, setLocalData] = useState(Array.isArray(data) ? data : []);
+
+  // Keep drafts in sync if parent values change while not editing
+  useEffect(() => {
+    if (!isEditing) {
+      setDraftMin(min);
+      setDraftMax(max);
+      setDraftWarning(warning);
+      setOrigMin(min);
+      setOrigMax(max);
+      setOrigWarning(warning);
+    }
+  }, [min, max, warning, isEditing]);
+
+  // Fetch last 30 minutes of readings (if Alert Detail passed sensorId)
+  useEffect(() => {
+    let cancelled = false;
+    const fetchRecent = async () => {
+      if (!sensorId || !supabase) {
+        setLocalData(Array.isArray(data) ? data : []);
+        return;
+      }
+      try {
+        const now = Date.now();
+        const thirtyMinAgoISO = new Date(now - 30 * 60 * 1000).toISOString();
+        const thirtyMinAgoSec = Math.floor((now - 30 * 60 * 1000) / 1000);
+
+        let { data: rows, error } = await supabase
+          .from('raw_readings_v2')
+          .select('reading_value, approx_time, timestamp')
+          .eq('sensor_id', sensorId)
+          .gte('approx_time', thirtyMinAgoISO)
+          .order('approx_time', { ascending: true });
+
+        if (error) throw error;
+
+        if (!rows || rows.length === 0) {
+          const { data: rows2, error: err2 } = await supabase
+            .from('raw_readings_v2')
+            .select('reading_value, timestamp')
+            .eq('sensor_id', sensorId)
+            .gte('timestamp', thirtyMinAgoSec)
+            .order('timestamp', { ascending: true });
+          if (err2) throw err2;
+          rows = rows2 || [];
+        }
+
+        const u = (unit || 'F').toUpperCase() === 'C' ? 'C' : 'F';
+        const vals = (rows || []).map((r) => toF(Number(r.reading_value), u));
+        if (!cancelled) {
+          setLocalData(vals.length ? vals : (Array.isArray(data) ? data : []));
+        }
+      } catch {
+        if (!cancelled) setLocalData(Array.isArray(data) ? data : []);
+      }
+    };
+    fetchRecent();
+    return () => { cancelled = true; };
+  }, [sensorId, unit, data]);
+
+  // Also load any saved limits from DB (if present) and apply once
+  useEffect(() => {
+    let cancelled = false;
+    const getLimits = async () => {
+      if (!sensorId || !supabase) return;
+      try {
+        const { data: row, error } = await supabase
+          .from('sensors')
+          .select('min_limit, max_limit, warning_limit')
+          .eq('sensor_id', sensorId)
+          .maybeSingle();
+        if (error) throw error;
+        if (!row) return;
+
+        const dbMin = Number(row.min_limit);
+        const dbMax = Number(row.max_limit);
+        const dbWarning = Number(row.warning_limit);
+        if (!cancelled && Number.isFinite(dbMin) && Number.isFinite(dbMax) && dbMin < dbMax) {
+          // update parent thresholds to DB values
+          onChange && onChange({ 
+            min: dbMin, 
+            max: dbMax, 
+            warning: Number.isFinite(dbWarning) ? dbWarning : Math.max(5, Math.floor((dbMax - dbMin) * 0.1))
+          });
+        }
+      } catch {
+        // ignore (no stored limits yet or RLS)
+      }
+    };
+    getLimits();
+  }, [sensorId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ---------- Geometry & helpers ----------
   const W = 720, H = 380;
   const padL = 60, padR = 56, padT = 18, padB = 28;
   const chartW = W - padL - padR, chartH = H - padT - padB;
 
-  const yMin = -20, yMax = 100;
+  // Dynamic zoom based on limits and data - only when not editing
+  const plotData = (localData && localData.length ? localData : data) || [];
+  const dataMin = plotData.length > 0 ? Math.min(...plotData) : min;
+  const dataMax = plotData.length > 0 ? Math.max(...plotData) : max;
+  const limitPadding = 10; // Add padding around limits for better visibility
+  
+  // Use static zoom while editing, dynamic zoom when not editing
+  const yMinScale = isEditing 
+    ? (editScaleMin !== null ? editScaleMin : Math.min(draftMin - limitPadding, -20)) // Use frozen scale while editing
+    : plotData.length > 0 
+      ? Math.min(min - limitPadding, Math.min(...plotData) - limitPadding)
+      : min - limitPadding;
+  const yMaxScale = isEditing 
+    ? (editScaleMax !== null ? editScaleMax : Math.max(draftMax + limitPadding, 100)) // Use frozen scale while editing
+      : plotData.length > 0 
+        ? Math.max(max + limitPadding, Math.max(...plotData) + limitPadding)
+        : max + limitPadding;
+  
+  const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
   const y = (t) =>
-    padT + chartH * (1 - (clamp(t, yMin, yMax) - yMin) / (yMax - yMin));
-  const x = (i) => padL + (chartW * i) / Math.max(1, data.length - 1);
-
-  const posToTemp = (clientY) => {
-    const rect = svgRef.current.getBoundingClientRect();
-    const yPix = clientY - rect.top;
-    const t = yMin + (1 - (yPix - padT) / chartH) * (yMax - yMin);
-    return clamp(Math.round(t), yMin, yMax);
+    padT + chartH * (1 - (clamp(t, yMinScale, yMaxScale) - yMinScale) / (yMaxScale - yMinScale));
+  const x = (i) => padL + (chartW * i) / Math.max(1, (plotData.length - 1));
+  
+  // Create line path with color based only on latest value
+  const createColoredLinePath = () => {
+    if (plotData.length === 0) return { path: '', segments: [] };
+    
+    // Only check the latest (most recent) value for line color
+    const latestValue = plotData[plotData.length - 1];
+    let lineColor = 'green';
+    
+    if (latestValue < min || latestValue > max) {
+      lineColor = 'red'; // Danger zone - latest value is in danger
+    } else if (latestValue <= min + warning || latestValue >= max - warning) {
+      lineColor = 'orange'; // Warning zone - latest value is in warning
+    }
+    // Otherwise stays green (latest value is in good zone)
+    
+    // Create single path for the entire line
+    let path = `M ${x(0)} ${y(plotData[0])}`;
+    for (let i = 1; i < plotData.length; i++) {
+      path += ` L ${x(i)} ${y(plotData[i])}`;
+    }
+    
+    return { 
+      path, 
+      segments: [{ path, color: lineColor, start: 0, end: plotData.length - 1 }] 
+    };
   };
-
-  const linePath = data.map((v, i) => `${i ? 'L' : 'M'} ${x(i)} ${y(v)}`).join(' ');
+  
+  const { segments } = createColoredLinePath();
 
   const strokeAxis = darkMode ? '#374151' : '#E5E7EB';
   const tickText = darkMode ? '#D1D5DB' : '#6B7280';
@@ -151,15 +328,31 @@ function ThresholdChart({ data, min, max, darkMode, onChange }) {
   const trackX = padL + chartW + 16;
   const trackW = 12, handleW = 18, handleH = 22, handleRX = 4;
 
-  const minWarnTop = Math.min(min + WARNING_MARGIN, max);
-  const maxWarnBot = Math.max(max - WARNING_MARGIN, min);
+  // Warning zones are now calculated directly in the SVG rectangles
 
+  // Drag logic: enabled only in edit mode
   useEffect(() => {
-    if (!drag) return;
+    if (!drag || !isEditing) return;
+
+    // Local helper: screen Y -> temp (°F)
+    const posToTemp = (clientY) => {
+      const rect = svgRef.current.getBoundingClientRect();
+      const yPix = clientY - rect.top;
+      const t = yMinScale + (1 - (yPix - padT) / chartH) * (yMaxScale - yMinScale);
+      return clamp(Math.round(t), yMinScale, yMaxScale);
+    };
+
     const move = (e) => {
       const t = posToTemp(e.clientY);
-      if (drag === 'max') onChange && onChange({ min, max: Math.max(min + 1, t) });
-      else onChange && onChange({ min: Math.min(max - 1, t), max });
+      if (drag === 'max') {
+        const next = Math.max(draftMin + 1, t);
+        setDraftMax(next);
+        // Don't call onChange while editing - only update local draft state
+      } else {
+        const next = Math.min(draftMax - 1, t);
+        setDraftMin(next);
+        // Don't call onChange while editing - only update local draft state
+      }
     };
     const up = () => setDrag(null);
     window.addEventListener('pointermove', move);
@@ -168,43 +361,456 @@ function ThresholdChart({ data, min, max, darkMode, onChange }) {
       window.removeEventListener('pointermove', move);
       window.removeEventListener('pointerup', up);
     };
-  }, [drag, min, max, onChange]);
+  }, [drag, isEditing, draftMin, draftMax, onChange, chartH]); // no posToTemp dep
+
+  // Positions for inline inputs (absolute, next to the track)
+  const containerStyles = 'relative w-full max-w-4xl overflow-visible';
+  const inputRight = 8; // px from SVG right edge
+  
+  // Use fixed pixel positions while editing to prevent jumping
+  const maxTop = isEditing 
+    ? (editScaleMax !== null ? padT + chartH * (1 - (clamp(draftMax, editScaleMin, editScaleMax) - editScaleMin) / (editScaleMax - editScaleMin)) - 12 : y(draftMax) - 12)
+    : y(max) - 12;
+  const minTop = isEditing 
+    ? (editScaleMax !== null ? padT + chartH * (1 - (clamp(draftMin, editScaleMin, editScaleMax) - editScaleMin) / (editScaleMax - editScaleMin)) - 12 : y(draftMin) - 12)
+    : y(min) - 12;
+
+  // Handlers
+  const startEdit = () => {
+    if (!editable) return;
+    setOrigMin(min);
+    setOrigMax(max);
+    setDraftMin(min);
+    setDraftMax(max);
+    
+    // Freeze the Y-scale at current values
+    const currentYMin = Math.min(min - limitPadding, -20);
+    const currentYMax = Math.max(max + limitPadding, 100);
+    setEditScaleMin(currentYMin);
+    setEditScaleMax(currentYMax);
+    
+    setIsEditing(true);
+    setSaveStatus('');
+  };
+
+  const cancelEdit = () => {
+    setIsEditing(false);
+    setSaveStatus('');
+    // Clear frozen scale
+    setEditScaleMin(null);
+    setEditScaleMax(null);
+    // revert parent state if changed
+    onChange && onChange({ min: origMin, max: origMax, warning: origWarning });
+  };
+
+  const saveEdit = async () => {
+    if (!sensorId || !supabase) {
+      setIsEditing(false);
+      return;
+    }
+    const nMin = Number(draftMin), nMax = Number(draftMax);
+    if (!(Number.isFinite(nMin) && Number.isFinite(nMax) && nMin < nMax)) return;
+
+    try {
+      setSaveStatus('saving');
+      // persist to DB (store Fahrenheit)
+      const { error } = await supabase
+        .from('sensors')
+        .update({
+          min_limit: nMin,
+          max_limit: nMax,
+          warning_limit: draftWarning,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('sensor_id', sensorId);
+      if (error) throw error;
+
+             // reflect in parent
+       onChange && onChange({ min: nMin, max: nMax, warning: draftWarning });
+       setOrigMin(nMin);
+       setOrigMax(nMax);
+       setOrigWarning(draftWarning);
+       // Clear frozen scale
+       setEditScaleMin(null);
+       setEditScaleMax(null);
+       setIsEditing(false);
+       setSaveStatus('saved');
+       setTimeout(() => setSaveStatus(''), 1500);
+    } catch (e) {
+      console.error('Save limits error:', e);
+      setSaveStatus('error');
+    }
+  };
+
+  // Input change helpers (live-preview while editing)
+  const setDraftMinClamped = (v) => {
+    let val = clamp(Math.round(v), yMinScale, yMaxScale);
+    val = Math.min(val, draftMax - 1);
+    setDraftMin(val);
+    // Don't call onChange while editing - only update local draft state
+  };
+  const setDraftMaxClamped = (v) => {
+    let val = clamp(Math.round(v), yMinScale, yMaxScale);
+    val = Math.max(val, draftMin + 1);
+    setDraftMax(val);
+    // Don't call onChange while editing - only update local draft state
+  };
+
+  // Colors for the inline inputs
+  const baseInput =
+    `w-16 h-6 text-xs rounded border px-1.5 py-0.5 text-right ` +
+    (darkMode ? 'bg-gray-700 text-white border-gray-600' : 'bg-white text-gray-800 border-gray-300') +
+    (isEditing ? '' : ' opacity-70 cursor-not-allowed');
 
   return (
-    <svg ref={svgRef} width={W} height={H} className="w-full max-w-4xl">
-      <rect x={padL} y={padT} width={chartW} height={chartH} fill="#FFFFFF" stroke={strokeAxis} />
-      <rect x={padL} y={padT} width={chartW} height={Math.max(0, y(max) - padT)} fill={red} opacity="0.22" />
-      <rect x={padL} y={y(min)} width={chartW} height={Math.max(0, padT + chartH - y(min))} fill={red} opacity="0.22" />
-      <rect x={padL} y={y(max)} width={chartW} height={Math.max(0, y(maxWarnBot) - y(max))} fill={orange} opacity="0.28" />
-      <rect x={padL} y={y(minWarnTop)} width={chartW} height={Math.max(0, y(min) - y(minWarnTop))} fill={orange} opacity="0.28" />
-      <line x1={padL} x2={padL + chartW} y1={y(max)} y2={y(max)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
-      <line x1={padL} x2={padL + chartW} y1={y(min)} y2={y(min)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
-      {[-20,-10,0,10,20,30,40,50,60,70,80,90,100].map((t) => (
-        <g key={t}>
-          <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
-          <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>{t}</text>
-        </g>
-      ))}
-      <path d={linePath} fill="none" stroke="#10B981" strokeWidth="3" strokeLinecap="round" />
-      {data.length > 0 && <circle cx={x(data.length - 1)} cy={y(data[data.length - 1])} r="5" fill="#10B981" />}
-      <rect x={trackX} y={padT} width={trackW} height={chartH} fill="#E5E7EB" stroke="#D1D5DB" />
-      <g transform={`translate(${trackX + trackW / 2}, ${y(max)})`} style={{ cursor: 'ns-resize' }}
-         onPointerDown={(e) => { e.preventDefault(); setDrag('max'); }}>
-        <rect x={-handleW/2} y={-handleH/2} width={handleW} height={handleH} rx={handleRX} fill="#FFFFFF" stroke="#9CA3AF" />
-        <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
-        <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
-        <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
-      </g>
-      <g transform={`translate(${trackX + trackW / 2}, ${y(min)})`} style={{ cursor: 'ns-resize' }}
-         onPointerDown={(e) => { e.preventDefault(); setDrag('min'); }}>
-        <rect x={-handleW/2} y={-handleH/2} width={handleW} height={handleH} rx={handleRX} fill="#FFFFFF" stroke="#9CA3AF" />
-        <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
-        <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
-        <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
-      </g>
-    </svg>
-  );
-}
+    <div ref={containerRef} className={containerStyles}>
+      {/* Edit / Save / Cancel controls (top-right of the chart) */}
+      {editable && (
+        <div className="flex items-center gap-2 absolute right-0 -top-10 z-20">
+          {!isEditing ? (
+            <button
+              type="button"
+              onClick={startEdit}
+              className={`px-3 py-1.5 rounded text-sm font-medium border ${
+                darkMode
+                  ? 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'
+                  : 'bg-white text-gray-800 border-gray-300 hover:bg-gray-100'
+              }`}
+              title="Enable editing of limits"
+            >
+              Edit limits
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className={`px-3 py-1.5 rounded text-sm ${
+                  darkMode ? 'bg-gray-600 text-white hover:bg-gray-700' : 'bg-gray-200 text-gray-800 hover:bg-gray-300'
+                }`}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={saveEdit}
+                className={`px-3 py-1.5 rounded text-sm font-semibold text-white ${
+                  darkMode ? 'bg-orange-700 hover:bg-orange-800' : 'bg-orange-500 hover:bg-orange-600'
+                }`}
+              >
+                {saveStatus === 'saving' ? 'Saving…' : 'Save'}
+              </button>
+              {saveStatus === 'error' && (
+                <span className={darkMode ? 'text-red-300 text-xs' : 'text-red-600 text-xs'}>Save failed</span>
+              )}
+              {saveStatus === 'saved' && (
+                <span className={darkMode ? 'text-green-300 text-xs' : 'text-green-600 text-xs'}>Saved</span>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+       <svg ref={svgRef} width={W} height={H} className="block">
+         <rect x={padL} y={padT} width={chartW} height={chartH} fill="#FFFFFF" stroke={strokeAxis} />
+
+                   {/* Red & orange bands */}
+          {/* Danger zones (red) - above max and below min */}
+          <rect x={padL} y={padT} width={chartW} height={Math.max(0, y(isEditing ? draftMax : max) - padT)} fill={red} opacity="0.22" />
+          <rect x={padL} y={y(isEditing ? draftMin : min)} width={chartW} height={Math.max(0, padT + chartH - y(isEditing ? draftMin : min))} fill={red} opacity="0.22" />
+          
+          {/* Warning zones (orange) - between danger and good zones */}
+          {/* Upper warning zone - between max and max-warning */}
+          <rect 
+            x={padL} 
+            y={y(isEditing ? draftMax : max)} 
+            width={chartW} 
+            height={Math.max(0, y(isEditing ? draftMax - draftWarning : max - warning) - y(isEditing ? draftMax : max))} 
+            fill={orange} 
+            opacity="0.15" 
+            stroke={orange}
+            strokeWidth="1"
+          />
+          {/* Lower warning zone - between min and min+warning */}
+          <rect 
+            x={padL} 
+            y={y(isEditing ? draftMin + (isEditing ? draftWarning : warning) : min + warning)} 
+            width={chartW} 
+            height={Math.max(0, y(isEditing ? draftMin : min) - y(isEditing ? draftMin + (isEditing ? draftWarning : warning) : min + warning))} 
+            fill={orange} 
+            opacity="0.15" 
+            stroke={orange}
+            strokeWidth="1"
+          />
+
+         {/* Limit lines */}
+         <line x1={padL} x2={padL + chartW} y1={y(isEditing ? draftMax : max)} y2={y(isEditing ? draftMax : max)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
+         <line x1={padL} x2={padL + chartW} y1={y(isEditing ? draftMin : min)} y2={y(isEditing ? draftMin : min)} stroke={red} strokeWidth="3" strokeDasharray="8 6" />
+
+                   {/* Y ticks - consistent while editing, dynamic when not editing */}
+          {(() => {
+            if (sensorType === 'humidity') {
+              // For humidity sensors, show percentage ticks (0-100%)
+              if (isEditing) {
+                // Use consistent percentage ticks while editing
+                const humidityTicks = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+                return humidityTicks.map((t) => (
+                  <g key={t}>
+                    <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
+                    <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                      {t}%
+                    </text>
+                  </g>
+                ));
+              } else {
+                // Dynamic percentage ticks based on zoom when not editing
+                const tickStep = Math.ceil((yMaxScale - yMinScale) / 10);
+                const ticks = [];
+                for (let t = Math.ceil(yMinScale / tickStep) * tickStep; t <= yMaxScale; t += tickStep) {
+                  if (t >= yMinScale && t <= yMaxScale) {
+                    ticks.push(t);
+                  }
+                }
+                return ticks.map((t) => (
+                  <g key={t}>
+                    <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
+                    <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                      {Math.round(t)}%
+                    </text>
+                  </g>
+                ));
+              }
+            } else {
+              // For temperature sensors, use existing temperature logic
+              if (isEditing) {
+                // Use consistent tick marks while editing for better UX
+                const baseTicks = userTempScale === 'C' 
+                  ? [-20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(fToC)
+                  : [-20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+                return baseTicks.map((t) => (
+                  <g key={t}>
+                    <line x1={padL - 6} x2={padL} y1={y(userTempScale === 'C' ? cToF(t) : t)} y2={y(userTempScale === 'C' ? cToF(t) : t)} stroke={strokeAxis} />
+                    <text x={padL - 10} y={y(userTempScale === 'C' ? cToF(t) : t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                      {Math.round(t)}{userTempScale === 'C' ? '°C' : '°F'}
+                    </text>
+                  </g>
+                ));
+              } else {
+                // Dynamic ticks based on zoom when not editing
+                const tickStep = Math.ceil((yMaxScale - yMinScale) / 10);
+                const ticks = [];
+                for (let t = Math.ceil(yMinScale / tickStep) * tickStep; t <= yMaxScale; t += tickStep) {
+                  if (t >= yMinScale && t <= yMaxScale) {
+                    ticks.push(t);
+                  }
+                }
+                return ticks.map((t) => (
+                  <g key={t}>
+                    <line x1={padL - 6} x2={padL} y1={y(t)} y2={y(t)} stroke={strokeAxis} />
+                    <text x={padL - 10} y={y(t) + 4} textAnchor="end" fontSize="12" fill={tickText}>
+                      {Math.round(convertForDisplay(t, userTempScale))}{userTempScale === 'C' ? '°C' : '°F'}
+                    </text>
+                  </g>
+                ));
+              }
+            }
+          })()}
+
+                   {/* Series - colored segments */}
+          {segments.map((segment, idx) => (
+            <g key={idx}>
+              {/* Glow effect for warning and danger zones */}
+              {segment.color !== 'green' && (
+                <path 
+                  d={segment.path} 
+                  fill="none" 
+                  stroke={segment.color === 'red' ? '#DC2626' : '#EA580C'} 
+                  strokeWidth="8" 
+                  strokeLinecap="round" 
+                  opacity="0.3"
+                  filter="blur(3px)"
+                />
+              )}
+              {/* Main line */}
+              <path 
+                d={segment.path} 
+                fill="none" 
+                stroke={segment.color === 'red' ? '#DC2626' : segment.color === 'orange' ? '#EA580C' : '#10B981'} 
+                strokeWidth="3" 
+                strokeLinecap="round" 
+              />
+            </g>
+          ))}
+         {plotData.length > 0 && (
+           <g>
+             {/* Glow effect for warning and danger zones */}
+             {(() => {
+               const temp = plotData[plotData.length - 1];
+               if (temp < min || temp > max) {
+                 // Danger zone - red glow
+                 return (
+                   <circle 
+                     cx={x(plotData.length - 1)} 
+                     cy={y(plotData[plotData.length - 1])} 
+                     r="12" 
+                     fill="#DC2626" 
+                     opacity="0.4"
+                     filter="blur(2px)"
+                   />
+                 );
+               } else if (temp <= min + warning || temp >= max - warning) {
+                 // Warning zone - orange glow
+                 return (
+                   <circle 
+                     cx={x(plotData.length - 1)} 
+                     cy={y(plotData[plotData.length - 1])} 
+                     r="12" 
+                     fill="#EA580C" 
+                     opacity="0.4"
+                     filter="blur(2px)"
+                   />
+                 );
+               }
+               return null;
+             })()}
+             {/* Main circle */}
+             <circle 
+               cx={x(plotData.length - 1)} 
+               cy={y(plotData[plotData.length - 1])} 
+               r="5" 
+               fill={(() => {
+                 const temp = plotData[plotData.length - 1];
+                 if (temp < min || temp > max) return '#DC2626'; // Red for danger
+                 if (temp <= min + warning || temp >= max - warning) return '#EA580C'; // Orange for warning
+                 return '#10B981'; // Green for good
+               })()}
+             />
+           </g>
+         )}
+
+                   {/* Track */}
+          <rect x={padL} y={padT} width={chartW} height={chartH} fill="transparent" />
+          <rect 
+            x={padL + chartW + 16} 
+            y={padT} 
+            width={12} 
+            height={chartH} 
+            fill="#E5E7EB" 
+            stroke="#D1D5DB" 
+            rx="2"
+            style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed' }}
+          />
+
+         {/* Handles (locked unless editing) */}
+                   <g
+            transform={`translate(${padL + chartW + 16 + 12 / 2}, ${y(isEditing ? draftMax : max)})`}
+            style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed', pointerEvents: isEditing ? 'auto' : 'none' }}
+            onPointerDown={(e) => { if (!isEditing) return; e.preventDefault(); setDrag('max'); }}
+          >
+            <rect x={-9} y={-11} width={18} height={22} rx={4} fill="#FFFFFF" stroke="#9CA3AF" />
+            <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
+            <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
+            <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
+          </g>
+
+          <g
+            transform={`translate(${padL + chartW + 16 + 12 / 2}, ${y(isEditing ? draftMin : min)})`}
+            style={{ cursor: isEditing ? 'ns-resize' : 'not-allowed', pointerEvents: isEditing ? 'auto' : 'none' }}
+            onPointerDown={(e) => { if (!isEditing) return; e.preventDefault(); setDrag('min'); }}
+          >
+            <rect x={-9} y={-11} width={18} height={22} rx={4} fill="#FFFFFF" stroke="#9CA3AF" />
+            <line x1={-5} x2={5} y1={-4} y2={-4} stroke="#9CA3AF" strokeWidth="2" />
+            <line x1={-5} x2={5} y1={0} y2={0} stroke="#9CA3AF" strokeWidth="2" />
+            <line x1={-5} x2={5} y1={4} y2={4} stroke="#9CA3AF" strokeWidth="2" />
+          </g>
+       </svg>
+
+               {/* Input fields positioned independently to the right of the chart */}
+        <div className="absolute right-0 top-0 w-28 space-y-3">
+                       {/* Max Limit Input */}
+            <div className="flex flex-col items-start">
+              <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                Max Limit
+              </label>
+              <input
+                type="number"
+                step="1"
+                min={sensorType === 'humidity' ? yMinScale : convertForDisplay(yMinScale, userTempScale)}
+                max={sensorType === 'humidity' ? yMaxScale : convertForDisplay(yMaxScale, userTempScale)}
+                value={isEditing 
+                  ? (sensorType === 'humidity' ? draftMax : convertForDisplay(draftMax, userTempScale))
+                  : (sensorType === 'humidity' ? max : convertForDisplay(max, userTempScale))
+                }
+                disabled={!isEditing}
+                onChange={(e) => {
+                  const displayVal = Number(e.target.value);
+                  if (sensorType === 'humidity') {
+                    setDraftMaxClamped(displayVal);
+                  } else {
+                    const fahrenheitVal = convertFromDisplay(displayVal, userTempScale);
+                    setDraftMaxClamped(fahrenheitVal);
+                  }
+                }}
+                className={baseInput}
+                title={`Max (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
+              />
+            </div>
+
+            {/* Min Limit Input */}
+            <div className="flex flex-col items-start">
+              <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                Min Limit
+              </label>
+              <input
+                type="number"
+                step="1"
+                min={sensorType === 'humidity' ? yMinScale : convertForDisplay(yMinScale, userTempScale)}
+                max={sensorType === 'humidity' ? yMaxScale : convertForDisplay(yMaxScale, userTempScale)}
+                value={isEditing 
+                  ? (sensorType === 'humidity' ? draftMin : convertForDisplay(draftMin, userTempScale))
+                  : (sensorType === 'humidity' ? min : convertForDisplay(min, userTempScale))
+                }
+                disabled={!isEditing}
+                onChange={(e) => {
+                  const displayVal = Number(e.target.value);
+                  if (sensorType === 'humidity') {
+                    setDraftMinClamped(displayVal);
+                  } else {
+                    const fahrenheitVal = convertFromDisplay(displayVal, userTempScale);
+                    setDraftMinClamped(fahrenheitVal);
+                  }
+                }}
+                className={baseInput}
+                title={`Min (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
+              />
+            </div>
+
+            {/* Warning Limit Input */}
+            <div className="flex flex-col items-start">
+              <label className={`text-xs font-medium mb-1 ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                Warning
+              </label>
+              <input
+                type="number"
+                step="1"
+                min="1"
+                max="20"
+                value={isEditing ? draftWarning : warning}
+                disabled={!isEditing}
+                onChange={(e) => {
+                  const val = Math.max(1, Math.min(20, Number(e.target.value)));
+                  setDraftWarning(val);
+                  // Don't call onChange while editing - only update local draft state
+                }}
+                className={baseInput}
+                title={`Warning margin (${sensorType === 'humidity' ? '%' : userTempScale === 'C' ? '°C' : '°F'})`}
+              />
+            </div>
+         </div>
+       </div>
+     
+   );
+ }
 
 // ---------- Main Component ----------
 export default function Alerts() {
@@ -219,27 +825,44 @@ export default function Alerts() {
   const router = useRouter();
   const { darkMode } = useDarkMode();
 
+  // User preferences for temperature scale
+  const [userTempScale, setUserTempScale] = useState('F'); // 'F' | 'C'
+
   // State
-  const [streams, setStreams] = useState([]);     // rows for UI list
-  const [thresholds, setThresholds] = useState({}); // id -> {min,max}
-  const [series, setSeries] = useState({});       // id -> number[]
+  const [streams, setStreams] = useState([]);       // rows for UI list
+  const [thresholds, setThresholds] = useState({}); // id -> {min,max,warning}
+  const [series, setSeries] = useState({});         // id -> number[]
   const HISTORY_LEN = 120;
 
   // Sensor Settings state / modal
   const [newSensorName, setNewSensorName] = useState('');
   const [newMetric, setNewMetric] = useState('F'); // 'C' | 'F' stored in DB
+  const [newSensorType, setNewSensorType] = useState('temperature'); // 'temperature' | 'humidity'
+ 
   const [savingSensorName, setSavingSensorName] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
 
   const makeKey = (sensor_id) => `${sensor_id}::temperature`;
 
-  // Session check
+  // Session check and load user preferences
   useEffect(() => {
     const checkSession = async () => {
       try {
         const { data: sessionData, error } = await supabase.auth.getSession();
         if (error) throw error;
         if (!sessionData.session) router.push('/login');
+        
+        // Load user temperature scale preference
+        const userId = sessionData.session.user.id;
+        const { data: prefsRow } = await supabase
+          .from('user_preferences')
+          .select('temp_scale')
+          .eq('user_id', userId)
+          .single();
+        
+        if (prefsRow?.temp_scale) {
+          setUserTempScale(prefsRow.temp_scale);
+        }
       } catch (err) {
         console.error('Session check error:', err.message);
         setError('Failed to verify session: ' + err.message);
@@ -249,13 +872,13 @@ export default function Alerts() {
     checkSession();
   }, [router]);
 
-  // Initial load: sensors list (read sensor_name + metric)
+  // Initial load: sensors list (read sensor_name + metric + limits)
   useEffect(() => {
     const load = async () => {
       try {
         const { data: sensorRows, error: sErr } = await supabase
           .from('sensors')
-          .select('sensor_id, sensor_name, metric, latest_temp, approx_time, last_fetched_time, updated_at');
+          .select('sensor_id, sensor_name, metric, latest_temp, approx_time, last_fetched_time, updated_at, min_limit, max_limit, sensor_type');
 
         if (sErr) throw sErr;
 
@@ -282,7 +905,11 @@ export default function Alerts() {
           const lr = latestMap.get(r.sensor_id);
 
           const raw = r.latest_temp ?? (lr ? Number(lr.reading_value) : null);
-          const tempF = raw != null ? toF(raw, unit) : null;
+          // For humidity sensors, keep raw percentage values (0-100)
+          // For temperature sensors, convert to Fahrenheit
+          const tempF = raw != null 
+            ? (r.sensor_type === 'humidity' ? Number(raw) : toF(raw, unit))
+            : null;
 
           const lastIso =
             r.approx_time ||
@@ -292,7 +919,11 @@ export default function Alerts() {
               new Date((Number(lr.timestamp) > 1e12 ? Number(lr.timestamp) : Number(lr.timestamp) * 1000)).toISOString()
             ) : null);
 
-          const th = DEFAULT_WARNING;
+                     const th = {
+             min: Number.isFinite(r?.min_limit) ? Number(r.min_limit) : 20,
+             max: Number.isFinite(r?.max_limit) ? Number(r.max_limit) : 60,
+             warning: Number.isFinite(r?.warning_limit) ? Number(r.warning_limit) : 5,
+           };
           nextThresholds[key] = th;
 
           return {
@@ -302,8 +933,9 @@ export default function Alerts() {
             status: computeStatus(tempF, th),
             lastReading: lastIso ? new Date(lastIso).toLocaleString() : 'No readings yet',
             sensor_id: r.sensor_id,
-            unit,                 // <--- stored unit (C or F)
-            metric: 'F',          // <--- displayed unit is always F
+            unit,     // stored unit (C or F)
+            metric: 'F', // displayed unit is always F
+            sensor_type: r.sensor_type || 'temperature', // 'temperature' | 'humidity'
           };
         });
 
@@ -324,7 +956,10 @@ export default function Alerts() {
   useEffect(() => {
     const sel = streams.find((s) => s.id === selectedId);
     setNewSensorName(sel ? (sel.name || '') : '');
-    setNewMetric(sel ? (sel.unit || 'F') : 'F');
+    const metric = sel ? (sel.unit || 'F') : 'F';
+    setNewMetric(metric);
+    // Auto-set sensor type based on metric
+    setNewSensorType(metric === '%' ? 'humidity' : 'temperature');
   }, [selectedId, streams]);
 
   // Load history when opening detail
@@ -345,7 +980,11 @@ export default function Alerts() {
         if (error) throw error;
 
         const unit = sel.unit || 'F';
-        const values = (data || []).map((d) => toF(d.reading_value, unit));
+        // For humidity sensors, keep raw percentage values
+        // For temperature sensors, convert to Fahrenheit
+        const values = (data || []).map((d) => 
+          sel.sensor_type === 'humidity' ? Number(d.reading_value) : toF(d.reading_value, unit)
+        );
         setSeries((prev) => ({
           ...prev,
           [selectedId]: values.length > 0 ? values : [sel.temp ?? 42],
@@ -374,9 +1013,14 @@ export default function Alerts() {
       setStreams((prev) => {
         const idx = prev.findIndex((p) => p.sensor_id === r.sensor_id);
         const unit = idx !== -1 ? prev[idx].unit : 'F';
-        const tempValF = toF(Number(r.reading_value), unit);
+        const sensorType = idx !== -1 ? prev[idx].sensor_type : 'temperature';
+        // For humidity sensors, keep raw percentage values
+        // For temperature sensors, convert to Fahrenheit
+        const tempValF = sensorType === 'humidity' 
+          ? Number(r.reading_value) 
+          : toF(Number(r.reading_value), unit);
         const id = idx !== -1 ? prev[idx].id : makeKey(r.sensor_id);
-        const th = thresholds[id] || DEFAULT_WARNING;
+        const th = thresholds[id] || { min: 20, max: 60 }; // fallback only if not loaded yet
         const name = idx !== -1 ? prev[idx].name : r.sensor_id;
 
         const row = {
@@ -400,7 +1044,12 @@ export default function Alerts() {
         const id = makeKey(r.sensor_id);
         const existing = streams.find((p) => p.sensor_id === r.sensor_id);
         const unit = existing?.unit || 'F';
-        const nextVal = toF(Number(r.reading_value), unit);
+        const sensorType = existing?.sensor_type || 'temperature';
+        // For humidity sensors, keep raw percentage values
+        // For temperature sensors, convert to Fahrenheit
+        const nextVal = sensorType === 'humidity' 
+          ? Number(r.reading_value) 
+          : toF(Number(r.reading_value), unit);
         const arr = prev[id] ? [...prev[id], nextVal] : [nextVal];
         return { ...prev, [id]: arr.slice(-HISTORY_LEN) };
       });
@@ -433,7 +1082,15 @@ export default function Alerts() {
         .maybeSingle();
       if (lErr) throw lErr;
 
-      const latestTempF = latest ? toF(latest.reading_value, unit) : null;
+      // Find the sensor to get its type
+      const sensor = streams.find(s => s.sensor_id === sensor_id);
+      const sensorType = sensor?.sensor_type || 'temperature';
+      
+      // For humidity sensors, keep raw percentage values
+      // For temperature sensors, convert to Fahrenheit
+      const latestTempF = latest 
+        ? (sensorType === 'humidity' ? Number(latest.reading_value) : toF(latest.reading_value, unit))
+        : null;
       const lastTime = latest ? toLocalFromReading(latest) : 'No readings yet';
 
       setStreams((prev) =>
@@ -461,7 +1118,11 @@ export default function Alerts() {
         .limit(HISTORY_LEN);
 
       if (!hErr && hist) {
-        const values = hist.map((d) => toF(d.reading_value, unit));
+        // For humidity sensors, keep raw percentage values
+        // For temperature sensors, convert to Fahrenheit
+        const values = hist.map((d) => 
+          sensorType === 'humidity' ? Number(d.reading_value) : toF(d.reading_value, unit)
+        );
         setSeries((prev) => ({ ...prev, [key]: values }));
       }
     } catch (e) {
@@ -480,7 +1141,9 @@ export default function Alerts() {
       return;
     }
 
-    const targetMetric = (newMetric || 'F').toUpperCase() === 'C' ? 'C' : 'F';
+    const targetMetric = newMetric === '%' ? '%' : 
+                     (newMetric || 'F').toUpperCase() === 'C' ? 'C' : 'F';
+    const targetSensorType = newSensorType || 'temperature';
 
     try {
       setSavingSensorName(true);
@@ -490,9 +1153,10 @@ export default function Alerts() {
       };
       if (nextName !== sel.name) updatePayload.sensor_name = nextName;
       if (targetMetric !== sel.unit) updatePayload.metric = targetMetric;
+      if (targetSensorType !== sel.sensor_type) updatePayload.sensor_type = targetSensorType;
 
       // if nothing changed, just close
-      if (!updatePayload.sensor_name && !updatePayload.metric) {
+      if (!updatePayload.sensor_name && !updatePayload.metric && !updatePayload.sensor_type) {
         setShowSettings(false);
         return;
       }
@@ -501,7 +1165,7 @@ export default function Alerts() {
         .from('sensors')
         .update(updatePayload)
         .eq('sensor_id', sel.sensor_id)
-        .select('sensor_id, sensor_name, metric')
+        .select('sensor_id, sensor_name, metric, sensor_type')
         .maybeSingle();
 
       if (error) {
@@ -513,13 +1177,15 @@ export default function Alerts() {
 
       // reflect DB values in UI
       const dbName = data.sensor_name ?? sel.name;
-      const dbUnit = (data.metric || sel.unit || 'F').toUpperCase() === 'C' ? 'C' : 'F';
+      const dbUnit = data.metric === '%' ? '%' : 
+                     (data.metric || sel.unit || 'F').toUpperCase() === 'C' ? 'C' : 'F';
+      const dbSensorType = data.sensor_type || sel.sensor_type || 'temperature';
 
       setStreams((prev) =>
         prev
           .map((row) =>
             row.sensor_id === sel.sensor_id
-              ? { ...row, name: dbName, unit: dbUnit }
+              ? { ...row, name: dbName, unit: dbUnit, sensor_type: dbSensorType }
               : row
           )
           .sort((a, b) => a.name.localeCompare(b.name))
@@ -549,7 +1215,7 @@ export default function Alerts() {
     setSelectedId(null);
   };
 
-  // Thresholds are local-only
+  // Update thresholds in state (used by list statuses and detail header)
   const updateThreshold = async (displayName, next) => {
     const item = streams.find((s) => s.name === displayName);
     if (!item) return;
@@ -593,7 +1259,11 @@ export default function Alerts() {
           </div>
           <div className="text-right">
             <div className={`${value} text-xl mb-1 font-bold`}>
-              🌡️ {sensor.temp != null && !Number.isNaN(sensor.temp) ? Math.round(sensor.temp) : '--'}°F
+              {sensor.sensor_type === 'humidity' ? (
+                '💧 ' + (sensor.temp != null && !Number.isNaN(sensor.temp) ? sensor.temp.toFixed(1) : '--') + '%'
+              ) : (
+                '🌡️ ' + (sensor.temp != null && !Number.isNaN(sensor.temp) ? convertForDisplay(sensor.temp, userTempScale).toFixed(1) : '--') + (userTempScale === 'C' ? '°C' : '°F')
+              )}
             </div>
           </div>
         </div>
@@ -684,26 +1354,8 @@ export default function Alerts() {
         <div className={`${darkMode ? 'bg-gray-700 text-gray-300' : 'bg-gray-100 text-gray-600'} p-3 rounded flex items-center`}>
           <span className="mr-3 text-xl">🛠️</span> System Alerts
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {[
-            { name: 'Meat Freezer', status: 'Disconnected', lastReading: '2 hours ago' },
-            { name: 'Fry Products', status: 'Need battery replacement', lastReading: '5 hours ago' },
-          ].map((a, i) => (
-            <div key={`sys-${i}`} className={`rounded-lg shadow p-4 border-l-4 border-gray-400 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-              <div className="flex justify-between items-center">
-                <div>
-                  <p className="font-semibold text-lg">{a.name}</p>
-                  <p className={`text-sm flex items-center mt-1 ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-                    <span className="mr-1">🕐</span> Last Reading: {a.lastReading}
-                  </p>
-                </div>
-                <div className="text-right">
-                  <div className="text-gray-500 text-2xl">{a.status === 'Disconnected' ? '📡' : '🔋'}</div>
-                  <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>{a.status}</p>
-                </div>
-              </div>
-            </div>
-          ))}
+        <div className={`col-span-full p-4 text-center ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+          No system alerts at this time
         </div>
 
         <div className="flex justify-end mt-8">
@@ -721,7 +1373,7 @@ export default function Alerts() {
   const renderAlertDetailView = () => {
     const selected = streams.find((s) => s.id === selectedId);
     if (!selected) return null;
-    const t = thresholds[selected.id] || DEFAULT_WARNING;
+    const t = thresholds[selected.id] || { min: 20, max: 60 };
     const data = series[selected.id] || (selected.temp != null ? [selected.temp] : []);
 
     return (
@@ -776,10 +1428,20 @@ export default function Alerts() {
               </div>
               <div className="flex items-center gap-3">
                 <div className={`${getStatusStyles(selected.status, darkMode).value} text-xl mb-1 font-bold`}>
-                  🌡️ {selected.temp != null ? Math.round(selected.temp) : '--'}°F
+                  {selected.sensor_type === 'humidity' ? (
+                    '💧 ' + (selected.temp != null ? selected.temp.toFixed(1) : '--') + '%'
+                  ) : (
+                    '🌡️ ' + (selected.temp != null ? convertForDisplay(selected.temp, userTempScale).toFixed(1) : '--') + (userTempScale === 'C' ? '°C' : '°F')
+                  )}
                 </div>
                 <button
-                  onClick={() => { setNewSensorName(selected.name || ''); setNewMetric(selected.unit || 'F'); setShowSettings(true); }}
+                  onClick={() => { 
+                    setNewSensorName(selected.name || ''); 
+                    const metric = selected.unit || 'F';
+                    setNewMetric(metric); 
+                    setNewSensorType(metric === '%' ? 'humidity' : 'temperature');
+                    setShowSettings(true); 
+                  }}
                   className={`px-3 py-1.5 rounded text-sm font-medium border ${
                     darkMode
                       ? 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'
@@ -814,21 +1476,58 @@ export default function Alerts() {
                   placeholder="Enter sensor display name"
                 />
 
+                <label className="block text-sm font-medium mb-2">Sensor Type</label>
+                <select
+                  value={newSensorType}
+                  onChange={(e) => {
+                    const type = e.target.value;
+                    setNewSensorType(type);
+                    // Auto-set metric based on sensor type
+                    if (type === 'humidity') {
+                      setNewMetric('%');
+                    } else {
+                      setNewMetric('F'); // Default to Fahrenheit for temperature
+                    }
+                  }}
+                  className={`border rounded px-3 py-2 w-full mb-4 ${
+                    darkMode
+                      ? 'bg-gray-700 text-white border-gray-600 focus:border-orange-500'
+                      : 'bg-white border-gray-300 focus:border-orange-500'
+                  } focus:outline-none focus:ring-2 focus:ring-orange-500/20`}
+                >
+                  <option value="temperature">Temperature</option>
+                  <option value="humidity">Humidity</option>
+                </select>
+
                 <label className="block text-sm font-medium mb-2">Metric (sensor unit)</label>
                 <select
                   value={newMetric}
-                  onChange={(e) => setNewMetric(e.target.value)}
+                  onChange={(e) => {
+                    const metric = e.target.value;
+                    setNewMetric(metric);
+                    // Auto-set sensor type based on metric
+                    setNewSensorType(metric === '%' ? 'humidity' : 'temperature');
+                  }}
                   className={`border rounded px-3 py-2 w-full mb-2 ${
                     darkMode
                       ? 'bg-gray-700 text-white border-gray-600 focus:border-orange-500'
                       : 'bg-white border-gray-300 focus:border-orange-500'
                   } focus:outline-none focus:ring-2 focus:ring-orange-500/20`}
                 >
-                  <option value="F">Fahrenheit (°F)</option>
-                  <option value="C">Celsius (°C)</option>
+                  {newSensorType === 'humidity' ? (
+                    <option value="%">Percentage (%)</option>
+                  ) : (
+                    <>
+                      <option value="F">Fahrenheit (°F)</option>
+                      <option value="C">Celsius (°C)</option>
+                    </>
+                  )}
                 </select>
                 <p className={`text-xs mb-4 ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-                  The dashboard always displays temperatures in <strong>°F</strong>. If your sensor reports in °C, we’ll convert to °F for display.
+                  {newSensorType === 'humidity' 
+                    ? 'Humidity sensors measure moisture levels in percentage.'
+                    : 'The dashboard always displays temperatures in °F. If your sensor reports in °C, we\'ll convert to °F for display.'
+                  }
                 </p>
 
                 <div className="flex justify-end gap-3">
@@ -858,28 +1557,36 @@ export default function Alerts() {
             </div>
           )}
 
-          <div className={`rounded-lg shadow p-6 border-2 border-blue-400 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-            <div className="flex justify-between items-center mb-4">
-              <div>
-                <h3 className="text-lg font-semibold">Temperature History</h3>
-                <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-                  {selected.name} • F
-                </p>
-              </div>
-              <div className="text-sm">
-                Limits: <strong>{t.min}°F</strong> – <strong>{t.max}°F</strong>
-              </div>
-            </div>
+                     <div className={`rounded-lg shadow p-6 border-2 border-blue-400 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
+             <div className="flex justify-between items-center mb-4">
+               <div>
+                 <h3 className="text-lg font-semibold">
+                   {selected.sensor_type === 'humidity' ? 'Humidity History' : 'Temperature History'}
+                 </h3>
+                 <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                   {selected.name} • {selected.sensor_type === 'humidity' ? '%' : 'F'}
+                 </p>
+               </div>
+               <div className="text-sm">
+                 Limits: <strong>{t.min}{selected.sensor_type === 'humidity' ? '%' : '°F'}</strong> – <strong>{t.max}{selected.sensor_type === 'humidity' ? '%' : '°F'}</strong>
+               </div>
+             </div>
 
-            <div className="flex justify-center">
-              <ThresholdChart
-                data={data}
-                min={t.min}
-                max={t.max}
-                darkMode={darkMode}
-                onChange={({ min, max }) => updateThreshold(selected.name, { min, max })}
-              />
-            </div>
+                         <div className="flex justify-start">
+                              <ThresholdChart
+                  data={data}
+                  min={t.min}
+                  max={t.max}
+                  warning={t.warning}
+                  darkMode={darkMode}
+                  onChange={({ min, max, warning }) => updateThreshold(selected.name, { min, max, warning })}
+                  sensorId={selected.sensor_id}
+                  unit={selected.unit}
+                  editable
+                  userTempScale={userTempScale}
+                  sensorType={selected.sensor_type}
+                />
+             </div>
           </div>
 
           <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
@@ -889,18 +1596,24 @@ export default function Alerts() {
                 <span>Time</span>
                 <span className="font-medium">{selected.lastReading}</span>
               </div>
-              <div className="flex justify-between">
-                <span>Threshold</span>
-                <span className="font-medium">{t.min}°F - {t.max}°F</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Air Temperature</span>
-                <span className="font-medium">{selected.temp != null ? Math.round(selected.temp) : '--'}°F</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Displayed Unit</span>
-                <span className="font-medium">Fahrenheit (°F)</span>
-              </div>
+                             <div className="flex justify-between">
+                 <span>Threshold</span>
+                 <span className="font-medium">
+                   {t.min}{selected.sensor_type === 'humidity' ? '%' : '°F'} - {t.max}{selected.sensor_type === 'humidity' ? '%' : '°F'}
+                 </span>
+               </div>
+               <div className="flex justify-between">
+                 <span>{selected.sensor_type === 'humidity' ? 'Humidity' : 'Air Temperature'}</span>
+                 <span className="font-medium">
+                   {selected.temp != null ? selected.temp.toFixed(1) : '--'}{selected.sensor_type === 'humidity' ? '%' : '°F'}
+                 </span>
+               </div>
+               <div className="flex justify-between">
+                 <span>Displayed Unit</span>
+                 <span className="font-medium">
+                   {selected.sensor_type === 'humidity' ? 'Percentage (%)' : 'Fahrenheit (°F)'}
+                 </span>
+               </div>
               <div className="flex justify-between">
                 <span>Sensor ID</span>
                 <span className="font-medium font-mono text-sm">{selected.sensor_id}</span>
@@ -958,13 +1671,14 @@ export default function Alerts() {
 
         <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
           <h4 className="text-lg font-semibold mb-2">Trigger</h4>
-          <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'} mb-6`}>
-            Drag the side handles to set minimum and maximum temperature limits. Warning zone is ±{WARNING_MARGIN}°F.
-          </p>
+                     <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-500'} mb-6`}>
+             Drag the side handles to set minimum and maximum temperature limits. Warning zone is configurable and will never overlap with the danger zone.
+           </p>
 
-          <div className="flex justify-center">
-            <ThresholdChart data={[32, 33, 31, 34, 30, 29]} min={25} max={40} darkMode={darkMode} />
-          </div>
+                     <div className="flex justify-center">
+             {/* Demo chart in Add Alert left unchanged */}
+                                                    <ThresholdChart data={[32, 33, 31, 34, 30, 29]} min={25} max={40} warning={3} darkMode={darkMode} userTempScale={userTempScale} sensorType="temperature" />
+           </div>
         </div>
 
         <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -1,433 +1,438 @@
-'use client';
+"use client";
 
-import { useState, useRef, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { createClient } from '@supabase/supabase-js';
-import Sidebar from '../../components/Sidebar';
-import { useDarkMode } from '../DarkModeContext';
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@supabase/supabase-js";
+import Sidebar from "../../components/Sidebar";
+import { useDarkMode } from "../DarkModeContext";
 
-// Supabase configuration
-const supabaseUrl = 'https://kwaylmatpkcajsctujor.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt3YXlsbWF0cGtjYWpzY3R1am9yIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNDAwMjQsImV4cCI6MjA3MDgxNjAyNH0.-ZICiwnXTGWgPNTMYvirIJ3rP7nQ9tIRC1ZwJBZM96M';
+/* ===== Supabase client ===== */
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://kwaylmatpkcajsctujor.supabase.co",
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt3YXlsbWF0cGtjYWpzY3R1am9yIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNDAwMjQsImV4cCI6MjA3MDgxNjAyNH0.-ZICiwnXTGWgPNTMYvirIJ3rP7nQ9tIRC1ZwJBZM96M"
+);
 
-// Initialize Supabase client
-let supabase;
-try {
-  supabase = createClient(supabaseUrl, supabaseAnonKey);
-  console.log('Supabase client initialized');
-} catch (err) {
-  console.error('Failed to initialize Supabase client:', err.message);
-}
+/* ===== Thresholds & helpers ===== */
+// Temperature thresholds (°F). Converted to °C as needed.
+const THRESHOLDS_F = {
+  fridge: { min: 35, max: 45, idealMin: 35, idealMax: 45 },
+  freezer: { min: -5, max: 5, idealMin: -5, idealMax: 5 },
+  default: { min: 20, max: 60, idealMin: 35, idealMax: 45 },
+};
+// Humidity thresholds (%RH)
+const HUMIDITY_THRESHOLDS = { min: 30, max: 60, idealMin: 30, idealMax: 60 };
 
-// Temperature thresholds for different sensor types
-const TEMPERATURE_THRESHOLDS = {
-  fridge: { min: 35, max: 45, ideal: 40 }, // Fridge should be around 35-45°F
-  freezer: { min: -5, max: 5, ideal: 0 }, // Freezer should be around -5 to 5°F
-  default: { min: 20, max: 60, ideal: 40 }
+const fToC = (v) => (v == null ? null : (v - 32) * 5 / 9);
+const cToF = (v) => (v == null ? null : v * 9 / 5 + 32);
+const convertVal = (v, fromUnit, toUnit) => {
+  if (v == null || fromUnit === toUnit) return v;
+  return fromUnit === "C" ? cToF(v) : fToC(v);
+};
+const getTempCategoryByName = (name, sensorId) => {
+  const s = (name || sensorId || "").toLowerCase();
+  if (s.includes("freezer") || s.includes("freeze")) return "freezer";
+  if (s.includes("fridge") || s.includes("refrigerator")) return "fridge";
+  return "default";
+};
+const computeStatusGeneric = (value, thresholds, pad = 3) => {
+  if (value == null) return "Good";
+  if (value < thresholds.min || value > thresholds.max) return "Needs Attention";
+  if (value <= thresholds.min + pad || value >= thresholds.max - pad) return "Warning";
+  return "Good";
 };
 
-const computeStatus = (temp, type = 'default') => {
-  if (temp == null) return 'Good';
-  
-  const threshold = TEMPERATURE_THRESHOLDS[type] || TEMPERATURE_THRESHOLDS.default;
-  const { min, max } = threshold;
-  
-  if (temp < min || temp > max) return 'Needs Attention';
-  if (temp <= min + 3 || temp >= max - 3) return 'Warning';
-  return 'Good';
+// Axis configs
+const axisConfigTemp = (unit) =>
+  unit === "F"
+    ? { min: 0, max: 100, step: 10, title: "🌡️ Temperature (0–100°F)", tickFmt: (n) => `${n}°F` }
+    : { min: -20, max: 40, step: 10, title: "🌡️ Temperature (-20–40°C)", tickFmt: (n) => `${n}°C` };
+const axisConfigHum = () => ({ min: 0, max: 100, step: 10, title: "💧 Humidity (0–100% RH)", tickFmt: (n) => `${n}%` });
+
+const fmtDate = (d, tz, withTime = true) => {
+  const opts = withTime
+    ? { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit", timeZone: tz }
+    : { year: "numeric", month: "2-digit", day: "2-digit", timeZone: tz };
+  try {
+    return new Intl.DateTimeFormat("en-US", opts).format(new Date(d));
+  } catch {
+    return new Date(d).toLocaleString();
+  }
 };
 
-const toF = (val, unit) => (val == null ? null : unit === 'C' ? (val * 9 / 5 + 32) : val);
-
-// Determine sensor type based on name or ID
-const getSensorType = (name, sensorId) => {
-  const nameStr = (name || sensorId || '').toLowerCase();
-  if (nameStr.includes('freezer') || nameStr.includes('freeze') || nameStr === 'temp1') {
-    return 'freezer';
-  }
-  if (nameStr.includes('fridge') || nameStr.includes('refrigerator')) {
-    return 'fridge';
-  }
-  if (nameStr.includes('humidity') || nameStr.includes('humid')) {
-    return 'fridge'; // Humidity sensors are usually in fridge
-  }
-  return 'fridge'; // Default to fridge
-};
+// Respect user prefs when filtering what to show
+const visibleItems = (items, selectedType, prefs) =>
+  items.filter((i) => {
+    if (selectedType === "temperature") return prefs.showTemp && i.kind === "temperature";
+    if (selectedType === "humidity") return prefs.showHumidity && i.kind === "humidity";
+    // ALL
+    if (i.kind === "temperature" && !prefs.showTemp) return false;
+    if (i.kind === "humidity" && !prefs.showHumidity) return false;
+    return true;
+  });
 
 export default function Dashboard() {
+  const router = useRouter();
+  const { darkMode, toggleDarkMode } = useDarkMode();
+
+  const [username, setUsername] = useState("User");
+  const [error, setError] = useState("");
+
+  // Preferences (from user_preferences)
+  const [prefs, setPrefs] = useState({
+    unit: "F", // 'F' | 'C' (temperature display)
+    tz: "America/Anchorage",
+    showTemp: true,
+    showHumidity: true,
+    showSensors: true,
+    showUsers: true,
+    showAlerts: true,
+  });
+
+  // Data
   const [data, setData] = useState({
     notifications: 0,
-    sensors: {
-      total: 0,
-      error: 0,
-      warning: 0,
-      success: 0,
-      disconnected: 0,
-    },
-    users: 6,
-    temperatures: [],
+    users: 0,
+    items: [], // unified (temperature + humidity)
+    sensors: { total: 0, error: 0, warning: 0, success: 0, disconnected: 0 },
     notificationsList: [],
   });
+
+  // Filter: 'all' | 'temperature' | 'humidity'
+  const [selectedType, setSelectedType] = useState("all");
+
+  // Notifications popup
   const [showNotifications, setShowNotifications] = useState(false);
-  const [notifications, setNotifications] = useState([]);
-  const [username, setUsername] = useState('User');
-  const [error, setError] = useState('');
   const popupRef = useRef(null);
   const notificationCardRef = useRef(null);
-  const { darkMode } = useDarkMode();
-  const router = useRouter();
 
-  // Fetch user session and set username
+  /* ===== Session + preferences ===== */
   useEffect(() => {
-    const checkSession = async () => {
+    (async () => {
       try {
-        console.log('Checking session...');
-        const { data: sessionData, error } = await supabase.auth.getSession();
-        if (error) throw error;
-        if (!sessionData.session) {
-          console.log('No session found, redirecting to login');
-          router.push('/login');
-        } else {
-          const user = sessionData.session.user;
-          const displayName = user?.user_metadata?.username || user?.email?.split('@')[0] || 'User';
-          console.log('Session found, user:', displayName);
-          setUsername(displayName);
+        const { data: s, error: e } = await supabase.auth.getSession();
+        if (e) throw e;
+        const session = s?.session;
+        if (!session) return router.push("/login");
+
+        const user = session.user;
+        setUsername(user?.user_metadata?.username || user?.email?.split("@")[0] || "User");
+
+        const { data: row } = await supabase
+          .from("user_preferences")
+          .select("*")
+          .eq("user_id", user.id)
+          .single();
+
+        if (row) {
+          const next = {
+            unit: row.temp_scale || "F",
+            tz: row.time_zone || "America/Anchorage",
+            showTemp: !!row.show_temp,
+            showHumidity: !!row.show_humidity,
+            showSensors: !!row.show_sensors,
+            showUsers: !!row.show_users,
+            showAlerts: !!row.show_alerts || !!row.show_notifications,
+          };
+          setPrefs(next);
+          if (!!row.dark_mode !== darkMode) toggleDarkMode();
         }
       } catch (err) {
-        console.error('Session check error:', err.message);
-        setError(
-          err.message === 'Failed to fetch'
-            ? 'Unable to connect to authentication server. Please check your network or contact support.'
-            : 'Failed to verify session: ' + err.message
-        );
-        router.push('/login');
+        setError("Failed to verify session: " + (err?.message || String(err)));
+        router.push("/login");
       }
-    };
-    checkSession();
-  }, [router]);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Process temperature data and generate notifications
-  const processTemperatureData = (temperatures) => {
-    const notificationsList = [];
-    let notificationId = 1;
-
-    temperatures.forEach(temp => {
-      if (temp.status === 'Needs Attention' || temp.status === 'Warning') {
-        notificationsList.push({
-          id: notificationId++,
-          title: `${temp.status} (${temp.name})`,
-          description: `Temperature: ${temp.displayValue} - ${temp.status === 'Needs Attention' ? 'Critical' : 'Warning'} level`,
-          date: new Date().toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' }),
-          type: temp.status === 'Needs Attention' ? 'error' : 'warning',
-          sensorId: temp.sensor_id,
-          temperature: temp.displayValue
+  const buildNotifications = (items, tz) => {
+    const list = [];
+    let id = 1;
+    items.forEach((it) => {
+      if (it.status === "Needs Attention" || it.status === "Warning") {
+        list.push({
+          id: id++,
+          title: `${it.status} (${it.name})`,
+          description: it.kind === "humidity" ? `Humidity: ${it.displayValue}` : `Temperature: ${it.displayValue}`,
+          date: fmtDate(Date.now(), tz, false),
+          type: it.status === "Needs Attention" ? "error" : "warning",
+          sensorId: it.sensor_id,
         });
       }
     });
-
-    return notificationsList;
+    return list;
   };
 
-  // Fetch sensors from Supabase
+  /* ===== Fetch sensors + latest readings ===== */
   useEffect(() => {
-    const fetchSensors = async () => {
+    (async () => {
       try {
         const { data: sensorRows, error: sErr } = await supabase
-          .from('sensors')
-          .select('sensor_id, sensor_name, metric, latest_temp, approx_time, last_fetched_time, updated_at');
-
+          .from("sensors")
+          .select("sensor_id, sensor_name, metric, sensor_type, latest_temp, approx_time, last_fetched_time, updated_at");
         if (sErr) throw sErr;
 
-        // Fallback latest from raw_readings_v2
-        const ids = (sensorRows || []).map(r => r.sensor_id).filter(Boolean);
+        const ids = (sensorRows || []).map((r) => r.sensor_id).filter(Boolean);
         let latestMap = new Map();
         if (ids.length) {
           const { data: latest, error: lErr } = await supabase
-            .from('raw_readings_v2')
-            .select('sensor_id, reading_value, timestamp, approx_time')
-            .in('sensor_id', ids)
-            .order('timestamp', { ascending: false });
+            .from("raw_readings_v2")
+            .select("sensor_id, reading_value, timestamp, approx_time")
+            .in("sensor_id", ids)
+            .order("timestamp", { ascending: false });
           if (lErr) throw lErr;
-          for (const row of latest) {
-            if (!latestMap.has(row.sensor_id)) latestMap.set(row.sensor_id, row);
-          }
+          for (const row of latest) if (!latestMap.has(row.sensor_id)) latestMap.set(row.sensor_id, row);
         }
 
-        const temperatures = (sensorRows || []).map(r => {
-          const unit = (r.metric || 'F').toUpperCase() === 'C' ? 'C' : 'F';
-          const lr = latestMap.get(r.sensor_id);
-          const raw = r.latest_temp ?? (lr ? Number(lr.reading_value) : null);
-          const value = raw != null ? toF(raw, unit) : null;
-          const name = r.sensor_name || r.sensor_id;
-          const type = getSensorType(name, r.sensor_id);
-          const status = computeStatus(value, type);
-          const color = status === 'Needs Attention' ? 'bg-red-500' : status === 'Warning' ? 'bg-yellow-500' : 'bg-green-500';
-          const displayValue = value != null ? `${Math.round(value)}°F` : '--°F';
+        const items = (sensorRows || [])
+          .map((r) => {
+            const sType = r.sensor_type || "sensor"; // 'sensor'|'temperature'|'humidity'
+            const kind = sType === "humidity" ? "humidity" : "temperature";
+            const name = r.sensor_name || r.sensor_id;
 
-          return {
-            sensor_id: r.sensor_id,
-            unit,
-            name,
-            value,
-            displayValue,
-            color,
-            type,
-            status,
-            lastUpdated: r.updated_at || lr?.timestamp || new Date().toISOString()
-          };
-        }).sort((a, b) => a.name.localeCompare(b.name));
+            const lr = latestMap.get(r.sensor_id);
+            const raw = r.latest_temp ?? (lr ? Number(lr.reading_value) : null);
 
-        // Generate notifications based on sensor status
-        const notificationsList = processTemperatureData(temperatures);
+            let value = null;
+            let displayValue = "--";
+            let status = "Good";
+            let color = "bg-green-500";
+            let unit = prefs.unit;
 
-        // Calculate sensor stats
-        const sensors = {
-          total: temperatures.length,
-          error: temperatures.filter(t => t.status === 'Needs Attention').length,
-          warning: temperatures.filter(t => t.status === 'Warning').length,
-          success: temperatures.filter(t => t.status === 'Good').length,
-          disconnected: temperatures.filter(t => t.value === null).length,
+            if (kind === "temperature") {
+              const sensorUnit = (r.metric || "F").toUpperCase() === "C" ? "C" : "F";
+              const v = convertVal(raw, sensorUnit, prefs.unit);
+              const category = getTempCategoryByName(name, r.sensor_id);
+              const base = THRESHOLDS_F[category] || THRESHOLDS_F.default;
+              const thr =
+                prefs.unit === "F"
+                  ? base
+                  : { min: fToC(base.min), max: fToC(base.max), idealMin: fToC(base.idealMin), idealMax: fToC(base.idealMax) };
+              value = v;
+              status = computeStatusGeneric(value, thr, prefs.unit === "F" ? 3 : 1.7);
+              displayValue = value != null ? `${Math.round(value)}°${prefs.unit}` : `--°${prefs.unit}`;
+            } else {
+              unit = "%";
+              value = raw != null ? Number(raw) : null;
+              status = computeStatusGeneric(value, HUMIDITY_THRESHOLDS, 5);
+              displayValue = value != null ? `${Math.round(value)}%` : "--%";
+            }
+
+            color = status === "Needs Attention" ? "bg-red-500" : status === "Warning" ? "bg-yellow-500" : "bg-green-500";
+
+            return {
+              sensor_id: r.sensor_id,
+              sensor_type: sType,
+              kind, // 'temperature' | 'humidity'
+              name,
+              unit,
+              value,
+              displayValue,
+              status,
+              color,
+              lastUpdated: r.updated_at || lr?.timestamp || new Date().toISOString(),
+            };
+          })
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        // Apply visibility for the selected type and prefs
+        const filtered = visibleItems(items, selectedType, prefs);
+
+        const sensorsKPI = {
+          total: filtered.length,
+          error: filtered.filter((t) => t.status === "Needs Attention").length,
+          warning: filtered.filter((t) => t.status === "Warning").length,
+          success: filtered.filter((t) => t.status === "Good").length,
+          disconnected: filtered.filter((t) => t.value == null).length,
         };
+
+        let usersCount = 0;
+        if (prefs.showUsers) {
+          const { count } = await supabase.from("team_members").select("id", { count: "exact", head: true });
+          if (typeof count === "number") usersCount = count;
+        }
+
+        const notificationsList = buildNotifications(filtered, prefs.tz);
 
         setData({
           notifications: notificationsList.length,
-          sensors,
-          users: 6,
-          temperatures,
+          users: usersCount,
+          items, // keep full set; we filter at render time too
+          sensors: sensorsKPI,
           notificationsList,
         });
-        setNotifications(notificationsList);
-        console.log('Sensors fetched successfully:', temperatures);
       } catch (err) {
-        console.error('Sensor fetch error:', err.message);
-        setError('Failed to fetch sensor data: ' + err.message);
-        
-        // Enhanced fallback data with realistic values
-        const fallbackTemperatures = [
-          { 
-            sensor_id: '284C4F41000000FF', 
-            unit: 'F', 
-            name: '284C4F41000000FF', 
-            value: 76, 
-            displayValue: '76°F', 
-            color: 'bg-red-500', 
-            type: 'fridge',
-            status: 'Needs Attention',
-            lastUpdated: new Date().toISOString()
-          },
-          { 
-            sensor_id: 'DHT22_Temp', 
-            unit: 'F', 
-            name: 'DHT22_Temp', 
-            value: 77, 
-            displayValue: '77°F', 
-            color: 'bg-red-500', 
-            type: 'fridge',
-            status: 'Needs Attention',
-            lastUpdated: new Date().toISOString()
-          },
-          { 
-            sensor_id: 'Humidity_Sensor', 
-            unit: 'F', 
-            name: 'Humidity Sensor', 
-            value: 67, 
-            displayValue: '67°F', 
-            color: 'bg-red-500', 
-            type: 'fridge',
-            status: 'Needs Attention',
-            lastUpdated: new Date().toISOString()
-          },
-        ];
-        
-        const fallbackNotifications = processTemperatureData(fallbackTemperatures);
-        
-        setData({
-          notifications: fallbackNotifications.length,
-          sensors: { 
-            total: 3, 
-            error: fallbackTemperatures.filter(t => t.status === 'Needs Attention').length,
-            warning: fallbackTemperatures.filter(t => t.status === 'Warning').length,
-            success: fallbackTemperatures.filter(t => t.status === 'Good').length,
-            disconnected: 0 
-          },
-          users: 6,
-          temperatures: fallbackTemperatures,
-          notificationsList: fallbackNotifications,
-        });
-        setNotifications(fallbackNotifications);
+        setError("Failed to fetch sensor data: " + (err?.message || String(err)));
       }
-    };
-    fetchSensors();
-  }, []);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefs.unit, prefs.showUsers, prefs.tz, prefs.showTemp, prefs.showHumidity, selectedType]);
 
-  // Realtime updates with proper notification handling
+  /* ===== Realtime updates ===== */
   useEffect(() => {
-    if (!supabase) return;
-
-    const onInsert = (payload) => {
-      const r = payload.new || {};
-      if (!r.sensor_id || r.reading_value == null) return;
-
-      setData((prev) => {
-        const prevTemps = prev.temperatures;
-        const idx = prevTemps.findIndex((p) => p.sensor_id === r.sensor_id);
-        if (idx === -1) return prev;
-
-        const unit = prevTemps[idx].unit;
-        const value = toF(Number(r.reading_value), unit);
-        const type = prevTemps[idx].type;
-        const status = computeStatus(value, type);
-        const color = status === 'Needs Attention' ? 'bg-red-500' : status === 'Warning' ? 'bg-yellow-500' : 'bg-green-500';
-        const displayValue = `${Math.round(value)}°F`;
-
-        const nextTemps = [...prevTemps];
-        nextTemps[idx] = { 
-          ...nextTemps[idx], 
-          value, 
-          displayValue, 
-          color, 
-          status,
-          lastUpdated: r.timestamp || new Date().toISOString()
-        };
-
-        const newNotif = processTemperatureData(nextTemps);
-
-        const newSensors = {
-          total: nextTemps.length,
-          error: nextTemps.filter((t) => t.status === 'Needs Attention').length,
-          warning: nextTemps.filter((t) => t.status === 'Warning').length,
-          success: nextTemps.filter((t) => t.status === 'Good').length,
-          disconnected: nextTemps.filter((t) => t.value === null).length,
-        };
-
-        setNotifications(newNotif);
-
-        return {
-          ...prev,
-          temperatures: nextTemps,
-          notifications: newNotif.length,
-          sensors: newSensors,
-          notificationsList: newNotif,
-        };
-      });
-    };
-
     const ch = supabase
-      .channel('raw-readings-v2-all')
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'raw_readings_v2' }, onInsert)
-      .subscribe((status) => {
-        console.log('Subscription status:', status);
-      });
+      .channel("raw-readings-v2-all")
+      .on("postgres_changes", { event: "INSERT", schema: "public", table: "raw_readings_v2" }, (payload) => {
+        const r = payload.new || {};
+        if (!r.sensor_id || r.reading_value == null) return;
 
-    return () => {
-      supabase.removeChannel(ch);
-    };
-  }, []);
+        setData((prev) => {
+          const items = [...prev.items];
+          const idx = items.findIndex((p) => p.sensor_id === r.sensor_id);
+          if (idx < 0) return prev;
 
-  // Handle click outside to close notifications
+          const item = items[idx];
+          if (item.kind === "temperature") {
+            // assume new value aligns with display unit already set for the item
+            const value = Number(r.reading_value);
+            const category = getTempCategoryByName(item.name, item.sensor_id);
+            const base = THRESHOLDS_F[category] || THRESHOLDS_F.default;
+            const thr =
+              item.unit === "F"
+                ? base
+                : { min: fToC(base.min), max: fToC(base.max), idealMin: fToC(base.idealMin), idealMax: fToC(base.idealMax) };
+            const status = computeStatusGeneric(value, thr, item.unit === "F" ? 3 : 1.7);
+            const color = status === "Needs Attention" ? "bg-red-500" : status === "Warning" ? "bg-yellow-500" : "bg-green-500";
+            items[idx] = {
+              ...item,
+              value,
+              displayValue: `${Math.round(value)}°${item.unit}`,
+              status,
+              color,
+              lastUpdated: r.timestamp || new Date().toISOString(),
+            };
+          } else {
+            const value = Number(r.reading_value);
+            const status = computeStatusGeneric(value, HUMIDITY_THRESHOLDS, 5);
+            const color = status === "Needs Attention" ? "bg-red-500" : status === "Warning" ? "bg-yellow-500" : "bg-green-500";
+            items[idx] = {
+              ...item,
+              value,
+              displayValue: `${Math.round(value)}%`,
+              status,
+              color,
+              lastUpdated: r.timestamp || new Date().toISOString(),
+            };
+          }
+
+          // Recompute KPIs/notifications with visibility
+          const filtered = visibleItems(items, selectedType, prefs);
+          const sensorsKPI = {
+            total: filtered.length,
+            error: filtered.filter((t) => t.status === "Needs Attention").length,
+            warning: filtered.filter((t) => t.status === "Warning").length,
+            success: filtered.filter((t) => t.status === "Good").length,
+            disconnected: filtered.filter((t) => t.value == null).length,
+          };
+          const notificationsList = buildNotifications(filtered, prefs.tz);
+
+          return { ...prev, items, sensors: sensorsKPI, notifications: notificationsList.length, notificationsList };
+        });
+      })
+      .subscribe();
+
+    return () => supabase.removeChannel(ch);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefs.tz, prefs.showTemp, prefs.showHumidity, selectedType]);
+
+  /* ===== UI helpers ===== */
   useEffect(() => {
-    const handleClickOutside = (event) => {
+    const handler = (e) => {
       if (
         popupRef.current &&
-        !popupRef.current.contains(event.target) &&
+        !popupRef.current.contains(e.target) &&
         notificationCardRef.current &&
-        !notificationCardRef.current.contains(event.target)
+        !notificationCardRef.current.contains(e.target)
       ) {
         setShowNotifications(false);
       }
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
   }, []);
 
-  // Handle sign-out
-  const handleSignOut = async () => {
-    try {
-      console.log('Attempting sign-out...');
-      const { error } = await supabase.auth.signOut();
-      if (error) throw error;
-      console.log('Sign-out successful');
-      router.push('/login');
-    } catch (err) {
-      console.error('Sign-out error:', err.message);
-      setError('Failed to sign out: ' + err.message);
-    }
+  const getInitials = (name) => name.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2);
+
+  // Axes
+  const axisTemp = axisConfigTemp(prefs.unit);
+  const axisHum = axisConfigHum();
+
+  // Which items are visible given filter + prefs
+  const itemsVisible = visibleItems(data.items, selectedType, prefs);
+
+  // In "all", decide which axes to show based on what's visible
+  const hasVisibleTemp = selectedType === "all" && itemsVisible.some((i) => i.kind === "temperature");
+  const hasVisibleHum = selectedType === "all" && itemsVisible.some((i) => i.kind === "humidity");
+
+  const leftAxis =
+    selectedType === "all"
+      ? hasVisibleTemp
+        ? axisTemp
+        : axisHum
+      : selectedType === "humidity"
+      ? axisHum
+      : axisTemp;
+
+  const rightAxis =
+    selectedType === "all" && hasVisibleTemp && hasVisibleHum
+      ? leftAxis === axisTemp
+        ? axisHum
+        : axisTemp
+      : null;
+
+  const H = 320;
+  const ticks = (ax) => {
+    const arr = [];
+    for (let v = ax.max; v >= ax.min; v -= ax.step) arr.push(ax.tickFmt(v));
+    return arr;
+  };
+  const toHeight = (item) => {
+    if (item.value == null) return 0;
+    const ax = item.kind === "humidity" ? axisHum : axisTemp;
+    const clamped = Math.max(ax.min, Math.min(item.value, ax.max));
+    return ((clamped - ax.min) / (ax.max - ax.min)) * H;
   };
 
-  // Close individual notification
-  const closeNotification = (id) => {
-    const updatedNotifications = notifications.filter((notification) => notification.id !== id);
-    setNotifications(updatedNotifications);
-    setData(prev => ({ 
-      ...prev, 
-      notifications: updatedNotifications.length,
-      notificationsList: updatedNotifications
-    }));
-  };
+  // Overlays for ideal zones
+  const tempBand = (() => {
+    const base =
+      prefs.unit === "F"
+        ? THRESHOLDS_F.fridge
+        : { min: fToC(THRESHOLDS_F.fridge.min), max: fToC(THRESHOLDS_F.fridge.max), idealMin: fToC(THRESHOLDS_F.fridge.idealMin), idealMax: fToC(THRESHOLDS_F.fridge.idealMax) };
+    const bottom = ((base.idealMin - axisTemp.min) / (axisTemp.max - axisTemp.min)) * H;
+    const height = ((base.idealMax - base.idealMin) / (axisTemp.max - axisTemp.min)) * H;
+    return { bottom, height };
+  })();
+  const humidityBand = (() => {
+    const bottom = ((HUMIDITY_THRESHOLDS.idealMin - axisHum.min) / (axisHum.max - axisHum.min)) * H;
+    const height = ((HUMIDITY_THRESHOLDS.idealMax - HUMIDITY_THRESHOLDS.idealMin) / (axisHum.max - axisHum.min)) * H;
+    return { bottom, height };
+  })();
 
-  // Clear all notifications
-  const clearAllNotifications = () => {
-    setNotifications([]);
-    setShowNotifications(false);
-    setData(prev => ({ 
-      ...prev, 
-      notifications: 0,
-      notificationsList: []
-    }));
-  };
-
-  // Calculate bar height for temperature graph with proper scaling (0-100°F)
-  const getBarHeight = (temp) => {
-    const actualChartHeight = 320; // Increased height for better precision
-    if (temp.value === null) {
-      return 0;
-    }
-    
-    // Universal scale 0-100°F for all sensors
-    const minTemp = 0;
-    const maxTemp = 100;
-    const range = maxTemp - minTemp;
-    const normalizedValue = Math.max(minTemp, Math.min(temp.value, maxTemp));
-    return ((normalizedValue - minTemp) / range) * actualChartHeight;
-  };
-
-  // Get initials for avatar
-  const getInitials = (name) => {
-    return name
-      .split(' ')
-      .map(word => word[0])
-      .join('')
-      .toUpperCase()
-      .slice(0, 2);
-  };
+  // Items to plot (respect prefs in ALL)
+  const chartItems = itemsVisible;
 
   return (
-    <div className={`flex min-h-screen ${darkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-800'}`}>
+    <div className={`flex min-h-screen ${darkMode ? "bg-gray-800 text-white" : "bg-white text-gray-800"}`}>
       <Sidebar />
       <main className="flex-1 p-6">
+        {/* Header */}
         <div className="flex justify-between items-center mb-6">
           <div>
             <h2 className="text-3xl font-bold">Dashboard</h2>
-            <p className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
-              Hi {username}
-            </p>
+            <p className={`text-sm ${darkMode ? "text-gray-300" : "text-gray-600"}`}>Hi {username}</p>
           </div>
           <div className="flex items-center space-x-3">
             <button
-              onClick={handleSignOut}
-              className={`bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 ${
-                darkMode ? 'bg-red-600 hover:bg-red-700' : ''
-              }`}
+              onClick={async () => {
+                await supabase.auth.signOut();
+                router.push("/login");
+              }}
+              className={`bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 ${darkMode ? "bg-red-600 hover:bg-red-700" : ""}`}
             >
               Log out
             </button>
-            <div
-              className={`w-10 h-10 rounded-full bg-amber-600 flex items-center justify-center text-white text-sm font-bold ${
-                darkMode ? 'bg-amber-700' : ''
-              }`}
-            >
+            <div className={`w-10 h-10 rounded-full bg-amber-600 flex items-center justify-center text-white text-sm font-bold ${darkMode ? "bg-amber-700" : ""}`}>
               {getInitials(username)}
             </div>
           </div>
@@ -435,379 +440,315 @@ export default function Dashboard() {
 
         {error && <p className="text-red-500 text-center mb-4">{error}</p>}
 
+        {/* KPI Cards */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-          <div
-            className={`rounded-lg p-6 shadow text-center relative ${
-              darkMode ? 'bg-gray-800 text-white' : 'bg-white'
-            }`}
-          >
-            <div
-              className="cursor-pointer"
-              onClick={() => setShowNotifications(!showNotifications)}
-              ref={notificationCardRef}
-            >
-              <div
-                className={`flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-4 mx-auto ${
-                  darkMode ? 'bg-green-900' : ''
-                }`}
-              >
-                <span className="text-2xl">🔔</span>
-              </div>
-              <p className={`text-gray-600 text-sm mb-1 ${darkMode ? 'text-gray-300' : ''}`}>Notifications</p>
-              <p className={`text-3xl font-bold text-gray-900 mb-2 ${darkMode ? 'text-white' : ''}`}>
-                {data.notifications}
-              </p>
-              <div className="flex items-center justify-center">
-                <div className={`w-2 h-2 bg-red-500 rounded-full mr-2 ${darkMode ? 'bg-red-400' : ''}`}></div>
-                <span className={`text-red-500 text-sm ${darkMode ? 'text-red-400' : ''}`}>
-                  {data.notifications > 0 ? 'Unread' : 'All Clear'}
-                </span>
-              </div>
-            </div>
-            {showNotifications && (
-              <div
-                ref={popupRef}
-                className={`absolute top-full left-1/2 transform -translate-x-1/2 mt-2 w-80 bg-white rounded-lg shadow-lg z-20 border border-gray-200 ${
-                  darkMode ? 'bg-gray-800 border-gray-700 text-white' : ''
-                }`}
-              >
-                <div className="p-4">
-                  <h4 className={`font-semibold text-gray-800 mb-3 ${darkMode ? 'text-white' : ''}`}>
-                    Notifications
-                  </h4>
-                  {notifications.length > 0 ? (
-                    notifications.map((notification) => (
-                      <div
-                        key={notification.id}
-                        className={`flex items-start justify-between p-3 mb-2 bg-gray-50 rounded-md ${
-                          darkMode ? 'bg-gray-700 text-white' : ''
-                        } ${notification.type === 'error' ? 'border-l-4 border-red-500' : 'border-l-4 border-yellow-500'}`}
-                      >
-                        <div className="flex-1">
-                          <p className={`text-gray-700 text-sm font-medium ${darkMode ? 'text-white' : ''}`}>
-                            {notification.title}
-                          </p>
-                          {notification.description && (
-                            <p className={`text-gray-600 text-xs ${darkMode ? 'text-gray-300' : ''}`}>
-                              {notification.description}
-                            </p>
-                          )}
-                          <p className={`text-gray-500 text-xs ${darkMode ? 'text-gray-400' : ''}`}>
-                            {notification.date}
-                          </p>
-                        </div>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            closeNotification(notification.id);
-                          }}
-                          className={`text-gray-400 hover:text-gray-600 ml-3 ${
-                            darkMode ? 'text-gray-300 hover:text-gray-200' : ''
-                          }`}
-                        >
-                          ✕
-                        </button>
-                      </div>
-                    ))
-                  ) : (
-                    <p className={`text-gray-500 text-sm text-center ${darkMode ? 'text-gray-300' : ''}`}>
-                      No new notifications.
-                    </p>
-                  )}
-                  {notifications.length > 0 && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        clearAllNotifications();
-                      }}
-                      className={`mt-4 w-full bg-blue-500 text-white py-2 rounded-md text-sm font-medium hover:bg-blue-600 ${
-                        darkMode ? 'bg-blue-600 hover:bg-blue-700' : ''
-                      }`}
-                    >
-                      Clear All
-                    </button>
-                  )}
+          {prefs.showAlerts && (
+            <div className={`rounded-lg p-6 shadow text-center relative ${darkMode ? "bg-gray-800 text-white" : "bg-white"}`}>
+              <div className="cursor-pointer" onClick={() => setShowNotifications(!showNotifications)} ref={notificationCardRef}>
+                <div className={`flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-4 mx-auto ${darkMode ? "bg-green-900" : ""}`}>
+                  <span className="text-2xl">🔔</span>
+                </div>
+                <p className={`text-gray-600 text-sm mb-1 ${darkMode ? "text-gray-300" : ""}`}>Notifications</p>
+                <p className={`text-3xl font-bold text-gray-900 mb-2 ${darkMode ? "text-white" : ""}`}>{data.notifications}</p>
+                <div className="flex items-center justify-center">
+                  <div className={`w-2 h-2 bg-red-500 rounded-full mr-2 ${darkMode ? "bg-red-400" : ""}`}></div>
+                  <span className={`text-red-500 text-sm ${darkMode ? "text-red-400" : ""}`}>{data.notifications > 0 ? "Unread" : "All Clear"}</span>
                 </div>
               </div>
-            )}
-          </div>
-          
-          <div className={`rounded-lg p-6 shadow text-center ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-            <div
-              className={`flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-4 mx-auto ${
-                darkMode ? 'bg-green-900' : ''
-              }`}
-            >
-              <span className="text-2xl">📶</span>
+              {showNotifications && (
+                <div ref={popupRef} className={`absolute top-full left-1/2 -translate-x-1/2 mt-2 w-80 bg-white rounded-lg shadow-lg z-20 border border-gray-200 ${darkMode ? "bg-gray-800 border-gray-700 text-white" : ""}`}>
+                  <div className="p-4">
+                    <h4 className={`font-semibold text-gray-800 mb-3 ${darkMode ? "text-white" : ""}`}>Notifications</h4>
+                    {data.notificationsList.length ? (
+                      data.notificationsList.map((n) => (
+                        <div key={n.id} className={`flex items-start justify-between p-3 mb-2 bg-gray-50 rounded-md ${darkMode ? "bg-gray-700 text-white" : ""} ${n.type === "error" ? "border-l-4 border-red-500" : "border-l-4 border-yellow-500"}`}>
+                          <div className="flex-1">
+                            <p className={`text-gray-700 text-sm font-medium ${darkMode ? "text-white" : ""}`}>{n.title}</p>
+                            {n.description && <p className={`text-gray-600 text-xs ${darkMode ? "text-gray-300" : ""}`}>{n.description}</p>}
+                            <p className={`text-gray-500 text-xs ${darkMode ? "text-gray-400" : ""}`}>{n.date}</p>
+                          </div>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              const rest = data.notificationsList.filter((x) => x.id !== n.id);
+                              setData((prev) => ({ ...prev, notificationsList: rest, notifications: rest.length }));
+                            }}
+                            className={`text-gray-400 hover:text-gray-600 ml-3 ${darkMode ? "text-gray-300 hover:text-gray-200" : ""}`}
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      ))
+                    ) : (
+                      <p className={`text-gray-500 text-sm text-center ${darkMode ? "text-gray-300" : ""}`}>No new notifications.</p>
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
-            <p className={`text-gray-600 text-sm mb-1 ${darkMode ? 'text-gray-300' : ''}`}>Sensors</p>
-            <p className={`text-3xl font-bold text-gray-900 mb-2 ${darkMode ? 'text-white' : ''}`}>
-              {data.sensors.total}
-            </p>
-            <div className="flex items-center justify-center space-x-3 text-sm">
-              <div className="flex items-center">
-                <div className={`w-2 h-2 bg-red-500 rounded-full mr-1 ${darkMode ? 'bg-red-400' : ''}`}></div>
-                <span className={`text-red-500 font-medium ${darkMode ? 'text-red-400' : ''}`}>
-                  {data.sensors.error}
-                </span>
+          )}
+
+          {prefs.showSensors && (
+            <div className={`rounded-lg p-6 shadow text-center ${darkMode ? "bg-gray-800 text-white" : "bg-white"}`}>
+              <div className={`flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-4 mx-auto ${darkMode ? "bg-green-900" : ""}`}>
+                <span className="text-2xl">📶</span>
               </div>
-              <div className="flex items-center">
-                <div className={`w-2 h-2 bg-yellow-500 rounded-full mr-1 ${darkMode ? 'bg-yellow-400' : ''}`}></div>
-                <span className={`text-yellow-500 font-medium ${darkMode ? 'text-yellow-400' : ''}`}>
-                  {data.sensors.warning}
-                </span>
-              </div>
-              <div className="flex items-center">
-                <div className={`w-2 h-2 bg-green-500 rounded-full mr-1 ${darkMode ? 'bg-green-400' : ''}`}></div>
-                <span className={`text-green-500 font-medium ${darkMode ? 'text-green-400' : ''}`}>
-                  {data.sensors.success}
-                </span>
-              </div>
-              <div className="flex items-center">
-                <span className={`mr-1 text-xs ${darkMode ? 'text-gray-300' : 'text-gray-500'}`}>✖</span>
-                <span className={`text-gray-500 font-medium ${darkMode ? 'text-gray-300' : ''}`}>
-                  {data.sensors.disconnected}
-                </span>
-              </div>
+              <p className={`text-gray-600 text-sm mb-1 ${darkMode ? "text-gray-300" : ""}`}>Sensors</p>
+              {(() => {
+                const kpiItems = itemsVisible;
+                return (
+                  <>
+                    <p className={`text-3xl font-bold text-gray-900 mb-2 ${darkMode ? "text-white" : ""}`}>{kpiItems.length}</p>
+                    <div className="flex items-center justify-center space-x-3 text-sm">
+                      <div className="flex items-center">
+                        <div className={`w-2 h-2 bg-red-500 rounded-full mr-1 ${darkMode ? "bg-red-400" : ""}`}></div>
+                        <span className={`text-red-500 font-medium ${darkMode ? "text-red-400" : ""}`}>
+                          {kpiItems.filter((t) => t.status === "Needs Attention").length}
+                        </span>
+                      </div>
+                      <div className="flex items-center">
+                        <div className={`w-2 h-2 bg-yellow-500 rounded-full mr-1 ${darkMode ? "bg-yellow-400" : ""}`}></div>
+                        <span className={`text-yellow-500 font-medium ${darkMode ? "text-yellow-400" : ""}`}>
+                          {kpiItems.filter((t) => t.status === "Warning").length}
+                        </span>
+                      </div>
+                      <div className="flex items-center">
+                        <div className={`w-2 h-2 bg-green-500 rounded-full mr-1 ${darkMode ? "bg-green-400" : ""}`}></div>
+                        <span className={`text-green-500 font-medium ${darkMode ? "text-green-400" : ""}`}>
+                          {kpiItems.filter((t) => t.status === "Good").length}
+                        </span>
+                      </div>
+                      <div className="flex items-center">
+                        <span className={`mr-1 text-xs ${darkMode ? "text-gray-300" : "text-gray-500"}`}>✖</span>
+                        <span className={`${darkMode ? "text-gray-300" : "text-gray-500"}`}>
+                          {kpiItems.filter((t) => t.value == null).length}
+                        </span>
+                      </div>
+                    </div>
+                  </>
+                );
+              })()}
             </div>
-          </div>
-          
-          <div className={`rounded-lg p-6 shadow text-center ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
-            <div
-              className={`flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-4 mx-auto ${
-                darkMode ? 'bg-green-900' : ''
-              }`}
-            >
-              <span className="text-2xl">👥</span>
+          )}
+
+          {prefs.showUsers && (
+            <div className={`rounded-lg p-6 shadow text-center ${darkMode ? "bg-gray-800 text-white" : "bg-white"}`}>
+              <div className={`flex items-center justify-center w-16 h-16 bg-green-100 rounded-full mb-4 mx-auto ${darkMode ? "bg-green-900" : ""}`}>
+                <span className="text-2xl">👥</span>
+              </div>
+              <p className={`text-gray-600 text-sm mb-1 ${darkMode ? "text-gray-300" : ""}`}>Users</p>
+              <p className={`text-3xl font-bold text-gray-900 mb-2 ${darkMode ? "text-white" : ""}`}>{data.users}</p>
             </div>
-            <p className={`text-gray-600 text-sm mb-1 ${darkMode ? 'text-gray-300' : ''}`}>Users</p>
-            <p className={`text-3xl font-bold text-gray-900 mb-2 ${darkMode ? 'text-white' : ''}`}>
-              {data.users}
-            </p>
-            <div className="flex justify-center -space-x-1">
-              <div
-                className={`w-6 h-6 bg-orange-500 rounded-full border-2 border-white ${darkMode ? 'border-gray-700' : ''}`}
-              ></div>
-              <div
-                className={`w-6 h-6 bg-blue-500 rounded-full border-2 border-white ${darkMode ? 'border-gray-700' : ''}`}
-              ></div>
-              <div
-                className={`w-6 h-6 bg-green-500 rounded-full border-2 border-white ${darkMode ? 'border-gray-700' : ''}`}
-              ></div>
-              <div
-                className={`w-6 h-6 bg-purple-500 rounded-full border-2 border-white ${darkMode ? 'border-gray-700' : ''}`}
-              ></div>
-              <div
-                className={`w-6 h-6 bg-pink-500 rounded-full border-2 border-white ${darkMode ? 'border-gray-700' : ''}`}
-              ></div>
-              <div
-                className={`w-6 h-6 bg-red-500 rounded-full border-2 border-white ${darkMode ? 'border-gray-700' : ''}`}
-              ></div>
-            </div>
-          </div>
+          )}
         </div>
 
-        <div className={`rounded-lg shadow p-6 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white'}`}>
+        {/* Chart + Table card */}
+        <div className={`rounded-lg shadow p-6 ${darkMode ? "bg-gray-800 text-white" : "bg-white"}`}>
           <div className="flex justify-between items-center mb-6">
-            <h3 className={`text-lg font-semibold text-gray-900 ${darkMode ? 'text-white' : ''}`}>
-              Temperature Monitoring System
+            <h3 className={`text-lg font-semibold ${darkMode ? "text-white" : "text-gray-900"}`}>
+              {selectedType === "all"
+                ? "All Sensors (respects Preferences)"
+                : selectedType === "humidity"
+                ? axisHum.title
+                : axisTemp.title}
             </h3>
-            <div className="text-sm text-gray-500">
-              Last updated: {new Date().toLocaleString()}
+            <div className="flex items-center gap-3">
+              <div className="text-sm text-gray-500">Last updated: {fmtDate(Date.now(), prefs.tz, true)}</div>
+              <div className="flex items-center gap-2">
+                <label className={`text-sm ${darkMode ? "text-gray-300" : "text-gray-600"}`}>Filter:</label>
+                <select
+                  value={selectedType}
+                  onChange={(e) => setSelectedType(e.target.value)}
+                  className={`border rounded px-2 py-1 ${darkMode ? "bg-gray-700 text-white border-gray-600" : "bg-white"}`}
+                >
+                  <option value="all">All</option>
+                  {prefs.showTemp && <option value="temperature">Temperature</option>}
+                  {prefs.showHumidity && <option value="humidity">Humidity</option>}
+                </select>
+              </div>
             </div>
           </div>
+
+          {/* Chart area (grid/axes always render) */}
           <div className="relative">
             <div className="flex items-start">
-              {/* Left Y-axis for Temperature Scale (0-100°F) */}
+              {/* Left Y-axis */}
               <div className="flex flex-col w-16 mr-3">
-                <div className="h-6"></div> {/* Spacer for title */}
+                <div className="h-6"></div>
                 <div className="relative h-80">
                   <div className="absolute inset-0 flex flex-col justify-between text-xs text-gray-600 items-end pr-3 font-medium">
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">100°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">90°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">80°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">70°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">60°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">50°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">40°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">30°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">20°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">10°F</span>
-                    <span className="transform -translate-y-1/2 bg-white px-1 rounded">0°F</span>
+                    {ticks(leftAxis).map((t, i) => (
+                      <span key={i} className="transform -translate-y-1/2 bg-white px-1 rounded">
+                        {t}
+                      </span>
+                    ))}
                   </div>
                 </div>
               </div>
 
-              {/* Main chart area */}
+              {/* Main plot */}
               <div className="flex-1 relative">
-                <div className="absolute -top-6 left-0 right-0 flex justify-between z-10">
-                  <span className={`text-green-600 font-semibold text-sm ${darkMode ? 'text-green-400' : ''}`}>
-                    🌡️ Temperature Monitoring (0-100°F Scale)
-                  </span>
-                  <div className="text-xs text-gray-500">
-                    Ideal: Fridge 35-45°F | Freezer -5 to 5°F
-                  </div>
-                </div>
-
-                {/* Enhanced Grid lines */}
+                {/* Grid */}
                 <div className="absolute inset-0 h-80">
                   <div className="h-full flex flex-col justify-between">
                     {[...Array(11)].map((_, i) => (
-                      <div key={i} className={`border-t w-full ${
-                        i === 0 || i === 10 ? 'border-gray-400 border-t-2' : 
-                        i === 5 ? 'border-gray-300 border-t-2' : 
-                        'border-gray-200'
-                      } ${darkMode ? 'border-gray-600' : ''}`}></div>
+                      <div
+                        key={i}
+                        className={`border-t w-full ${
+                          i === 0 || i === 10 ? "border-gray-400 border-t-2" : i === 5 ? "border-gray-300 border-t-2" : "border-gray-200"
+                        } ${darkMode ? "border-gray-600" : ""}`}
+                      />
                     ))}
                   </div>
                   <div className="absolute inset-0">
-                    <div className={`absolute left-0 top-0 bottom-0 w-1 bg-gray-400 ${darkMode ? 'bg-gray-500' : ''}`}></div>
-                    <div className={`absolute right-0 top-0 bottom-0 w-1 bg-gray-400 ${darkMode ? 'bg-gray-500' : ''}`}></div>
-                  </div>
-                </div>
-                
-                {/* Temperature ideal range indicators */}
-                <div className="absolute inset-0 h-80 pointer-events-none">
-                  {/* Fridge ideal range (35-45°F) */}
-                  <div 
-                    className="absolute left-0 bg-green-100 bg-opacity-50 border-t-2 border-b-2 border-green-500"
-                    style={{
-                      bottom: `${(35/100) * 320}px`,
-                      height: `${((45-35)/100) * 320}px`,
-                      width: '100%',
-                      borderStyle: 'dashed'
-                    }}
-                  >
-                    <div className="absolute left-2 top-1/2 transform -translate-y-1/2 text-xs font-bold text-green-700 bg-green-200 px-2 py-1 rounded">
-                      Fridge Ideal Zone
-                    </div>
-                  </div>
-                  
-                  {/* Critical temperature zones */}
-                  <div 
-                    className="absolute left-0 bg-red-100 bg-opacity-30 border-t border-red-400"
-                    style={{
-                      bottom: `${(80/100) * 320}px`,
-                      height: `${((100-80)/100) * 320}px`,
-                      width: '100%'
-                    }}
-                  >
-                    <div className="absolute left-2 top-2 text-xs font-bold text-red-700 bg-red-200 px-2 py-1 rounded">
-                      Danger Zone
-                    </div>
+                    <div className={`absolute left-0 top-0 bottom-0 w-1 bg-gray-400 ${darkMode ? "bg-gray-500" : ""}`}></div>
+                    <div className={`absolute right-0 top-0 bottom-0 w-1 bg-gray-400 ${darkMode ? "bg-gray-500" : ""}`}></div>
                   </div>
                 </div>
 
-                {/* Temperature bars with enhanced styling */}
+                {/* Ideal bands (show what's relevant) */}
+                <div className="absolute inset-0 h-80 pointer-events-none">
+                  {(selectedType !== "humidity") && (hasVisibleTemp || selectedType !== "all") && (
+                    <div
+                      className="absolute left-0 bg-green-100 bg-opacity-50 border-t-2 border-b-2 border-green-500"
+                      style={{
+                        bottom: `${tempBand.bottom}px`,
+                        height: `${tempBand.height}px`,
+                        width: "100%",
+                        borderStyle: "dashed",
+                      }}
+                    >
+                      <div className="absolute left-2 top-1/2 -translate-y-1/2 text-xs font-bold text-green-700 bg-green-200 px-2 py-1 rounded">
+                        Fridge Ideal (Temp)
+                      </div>
+                    </div>
+                  )}
+                  {(selectedType !== "temperature") && (hasVisibleHum || selectedType !== "all") && (
+                    <div
+                      className="absolute left-0 bg-green-100 bg-opacity-50 border-t-2 border-b-2 border-green-500"
+                      style={{
+                        bottom: `${((HUMIDITY_THRESHOLDS.idealMin - axisHum.min) / (axisHum.max - axisHum.min)) * H}px`,
+                        height: `${((HUMIDITY_THRESHOLDS.idealMax - HUMIDITY_THRESHOLDS.idealMin) / (axisHum.max - axisHum.min)) * H}px`,
+                        width: "100%",
+                        borderStyle: "dashed",
+                      }}
+                    >
+                      <div className="absolute left-2 top-1/2 -translate-y-1/2 text-xs font-bold text-green-700 bg-green-200 px-2 py-1 rounded">
+                        Comfort Zone (Humidity)
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Bars (or empty) */}
                 <div className="relative h-80">
                   <div className="absolute bottom-0 left-0 right-0 flex justify-around items-end h-full px-6">
-                    {data.temperatures.map((temp, i) => {
-                      const barHeight = getBarHeight(temp);
-                      return (
-                        <div key={i} className="flex flex-col items-center relative group" style={{ flexBasis: '30%', maxWidth: '100px' }}>
-                          {/* Temperature value label */}
-                          {temp.value !== null && (
-                            <div
-                              className={`absolute text-sm font-bold px-3 py-2 rounded-lg shadow-lg z-20 transition-all duration-300 group-hover:scale-110 ${
-                                temp.status === 'Needs Attention' 
-                                  ? 'bg-red-500 text-white border-2 border-red-600 animate-bounce' 
-                                  : temp.status === 'Warning'
-                                  ? 'bg-yellow-500 text-white border-2 border-yellow-600'
-                                  : 'bg-green-500 text-white border-2 border-green-600'
-                              }`}
-                              style={{
-                                bottom: `${barHeight + 12}px`,
-                                left: '50%',
-                                transform: 'translateX(-50%)',
-                                whiteSpace: 'nowrap',
-                                boxShadow: '0 4px 12px rgba(0,0,0,0.15)'
-                              }}
-                            >
-                              {temp.displayValue}
-                              <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-current"></div>
-                            </div>
-                          )}
-                          
-                          {/* Temperature bar */}
-                          {temp.value !== null && (
-                            <div
-                              className={`relative w-16 rounded-t-lg shadow-xl transition-all duration-500 group-hover:w-20 ${temp.color} ${
-                                temp.status === 'Needs Attention' ? 'animate-pulse' : ''
-                              }`}
-                              style={{ 
-                                height: `${Math.max(barHeight, 8)}px`,
-                                background: temp.status === 'Needs Attention' 
-                                  ? 'linear-gradient(to top, #dc2626, #ef4444)' 
-                                  : temp.status === 'Warning'
-                                  ? 'linear-gradient(to top, #d97706, #f59e0b)'
-                                  : 'linear-gradient(to top, #059669, #10b981)',
-                                boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
-                              }}
-                              title={`${temp.name}: ${temp.displayValue} (${temp.status})`}
-                            >
-                              {/* Bar pattern for visual appeal */}
-                              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white to-transparent opacity-20 rounded-t-lg"></div>
-                            </div>
-                          )}
-                          
-                          {/* No data indicator */}
-                          {temp.value === null && (
-                            <div
-                              className="bg-gray-400 w-16 rounded-t-lg opacity-50"
-                              style={{ height: '8px' }}
-                              title={`${temp.name}: No data available`}
-                            >
-                              <div className="text-xs text-center text-gray-600 mt-1">No Data</div>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
+                    {chartItems.length === 0 ? (
+                      <div className="text-center w-full text-sm text-gray-500 mt-20 opacity-75">No sensors to display.</div>
+                    ) : (
+                      chartItems.map((it, i) => {
+                        const h = toHeight(it);
+                        const label = it.kind === "humidity" ? (it.value != null ? `${Math.round(it.value)}%` : "--%") : it.displayValue;
+                        return (
+                          <div key={i} className="flex flex-col items-center relative group" style={{ flexBasis: "22%", maxWidth: "120px" }}>
+                            {it.value != null && (
+                              <div
+                                className={`absolute text-sm font-bold px-3 py-2 rounded-lg shadow-lg z-20 transition-all duration-300 group-hover:scale-110 ${
+                                  it.status === "Needs Attention"
+                                    ? "bg-red-500 text-white border-2 border-red-600 animate-bounce"
+                                    : it.status === "Warning"
+                                    ? "bg-yellow-500 text-white border-2 border-yellow-600"
+                                    : "bg-green-500 text-white border-2 border-green-600"
+                                }`}
+                                style={{
+                                  bottom: `${h + 12}px`,
+                                  left: "50%",
+                                  transform: "translateX(-50%)",
+                                  whiteSpace: "nowrap",
+                                  boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                                }}
+                              >
+                                {label}
+                                <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-current"></div>
+                              </div>
+                            )}
+                            {it.value != null ? (
+                              <div
+                                className={`relative w-16 rounded-t-lg shadow-xl transition-all duration-500 group-hover:w-20 ${it.color} ${
+                                  it.status === "Needs Attention" ? "animate-pulse" : ""
+                                }`}
+                                style={{
+                                  height: `${Math.max(h, 8)}px`,
+                                  background:
+                                    it.status === "Needs Attention"
+                                      ? "linear-gradient(to top, #dc2626, #ef4444)"
+                                      : it.status === "Warning"
+                                      ? "linear-gradient(to top, #d97706, #f59e0b)"
+                                      : "linear-gradient(to top, #059669, #10b981)",
+                                  boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+                                }}
+                                title={`${it.name}: ${label} (${it.status})`}
+                              >
+                                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white to-transparent opacity-20 rounded-t-lg"></div>
+                              </div>
+                            ) : (
+                              <div className="bg-gray-400 w-16 rounded-t-lg opacity-50" style={{ height: "8px" }} title={`${it.name}: No data`}>
+                                <div className="text-xs text-center text-gray-600 mt-1">No Data</div>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })
+                    )}
                   </div>
                 </div>
 
-                {/* Enhanced sensor labels */}
-                <div className={`flex justify-around mt-4 pt-3 px-6 ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>
-                  {data.temperatures.map((temp, i) => (
-                    <div key={i} className="text-center group cursor-pointer" style={{ flexBasis: '30%', maxWidth: '100px' }}>
-                      <p className="text-sm font-bold truncate group-hover:text-blue-600 transition-colors">{temp.name}</p>
-                      <p className={`text-xs font-semibold px-2 py-1 rounded-full mt-1 ${
-                        temp.status === 'Needs Attention' ? 'bg-red-100 text-red-700' :
-                        temp.status === 'Warning' ? 'bg-yellow-100 text-yellow-700' : 'bg-green-100 text-green-700'
-                      }`}>
-                        {temp.status}
+                {/* Labels below bars */}
+                <div className={`flex justify-around mt-4 pt-3 px-6 ${darkMode ? "text-gray-300" : "text-gray-700"}`}>
+                  {chartItems.map((it, i) => (
+                    <div key={i} className="text-center group cursor-pointer" style={{ flexBasis: "22%", maxWidth: "120px" }}>
+                      <p className="text-sm font-bold truncate group-hover:text-blue-600 transition-colors">{it.name}</p>
+                      <p
+                        className={`text-xs font-semibold px-2 py-1 rounded-full mt-1 ${
+                          it.status === "Needs Attention"
+                            ? "bg-red-100 text-red-700"
+                            : it.status === "Warning"
+                            ? "bg-yellow-100 text-yellow-700"
+                            : "bg-green-100 text-green-700"
+                        }`}
+                      >
+                        {it.status}
                       </p>
-                      <p className="text-xs text-gray-500 mt-1 capitalize">{temp.type} sensor</p>
+                      <p className="text-xs text-gray-500 mt-1">{it.kind}</p>
                     </div>
                   ))}
                 </div>
               </div>
 
-              {/* Right side reference */}
+              {/* Right Y-axis: humidity ticks when visible alongside temp */}
               <div className="flex flex-col w-16 ml-3">
                 <div className="h-6"></div>
                 <div className="relative h-80">
                   <div className="absolute inset-0 flex flex-col justify-between text-xs text-gray-500 items-start pl-3">
-                    <span className="bg-red-100 px-1 rounded text-red-700">Critical</span>
-                    <span className="bg-yellow-100 px-1 rounded text-yellow-700">Hot</span>
-                    <span className="bg-orange-100 px-1 rounded text-orange-700">Warm</span>
-                    <span className="bg-blue-100 px-1 rounded text-blue-700">Room</span>
-                    <span className="bg-green-100 px-1 rounded text-green-700">Cool</span>
-                    <span className="bg-green-200 px-1 rounded text-green-800">Ideal</span>
-                    <span className="bg-cyan-100 px-1 rounded text-cyan-700">Cold</span>
-                    <span className="bg-blue-200 px-1 rounded text-blue-800">Very Cold</span>
-                    <span className="bg-purple-100 px-1 rounded text-purple-700">Freezing</span>
-                    <span className="bg-indigo-100 px-1 rounded text-indigo-700">Ice</span>
-                    <span className="bg-gray-100 px-1 rounded text-gray-700">Frozen</span>
+                    {rightAxis
+                      ? ticks(rightAxis).map((t, i) => (
+                          <span key={i} className="bg-white px-1 rounded">
+                            {t}
+                          </span>
+                        ))
+                      : ["Critical", "Hot", "Warm", "Room", "Cool", "Ideal", "Cold", "Very Cold", "Freezing", "Ice", "Frozen"].map(
+                          (t, i) => (
+                            <span key={i} className="bg-gray-100 px-1 rounded text-gray-700">
+                              {t}
+                            </span>
+                          )
+                        )}
                   </div>
                 </div>
               </div>
             </div>
-            <div className="text-center mt-4">
-              <span className={`text-sm text-gray-600 font-medium ${darkMode ? 'text-gray-300' : ''}`}>Sensors</span>
-            </div>
-            
-            {/* Temperature status legend */}
+
+            {/* Legend */}
             <div className="flex justify-center mt-4 space-x-6 text-xs">
               <div className="flex items-center">
                 <div className="w-3 h-3 bg-green-500 rounded mr-2"></div>
@@ -823,49 +764,48 @@ export default function Dashboard() {
               </div>
             </div>
 
-            {/* Sensor details table */}
+            {/* Table */}
             <div className="mt-6">
-              <h4 className={`text-md font-semibold mb-3 ${darkMode ? 'text-white' : 'text-gray-900'}`}>
-                Sensor Details
-              </h4>
+              <h4 className={`text-md font-semibold mb-3 ${darkMode ? "text-white" : "text-gray-900"}`}>Sensor Details</h4>
               <div className="overflow-x-auto">
-                <table className={`w-full text-sm ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                <table className={`w-full text-sm ${darkMode ? "text-gray-300" : "text-gray-600"}`}>
                   <thead>
-                    <tr className={`border-b ${darkMode ? 'border-gray-700' : 'border-gray-200'}`}>
+                    <tr className={`border-b ${darkMode ? "border-gray-700" : "border-gray-200"}`}>
                       <th className="text-left py-2">Sensor</th>
-                      <th className="text-left py-2">Temperature</th>
-                      <th className="text-left py-2">Status</th>
                       <th className="text-left py-2">Type</th>
+                      <th className="text-left py-2">Reading</th>
+                      <th className="text-left py-2">Status</th>
                       <th className="text-left py-2">Last Updated</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {data.temperatures.map((temp, i) => (
-                      <tr key={i} className={`border-b ${darkMode ? 'border-gray-700' : 'border-gray-100'}`}>
-                        <td className="py-2 font-medium">{temp.name}</td>
+                    {itemsVisible.map((it, i) => (
+                      <tr key={i} className={`border-b ${darkMode ? "border-gray-700" : "border-gray-100"}`}>
+                        <td className="py-2 font-medium">{it.name}</td>
+                        <td className="py-2 capitalize">{it.kind}</td>
                         <td className="py-2">
-                          <span className={`font-bold ${
-                            temp.status === 'Needs Attention' ? 'text-red-500' :
-                            temp.status === 'Warning' ? 'text-yellow-500' : 'text-green-500'
-                          }`}>
-                            {temp.displayValue}
+                          <span
+                            className={`font-bold ${
+                              it.status === "Needs Attention" ? "text-red-500" : it.status === "Warning" ? "text-yellow-500" : "text-green-500"
+                            }`}
+                          >
+                            {it.kind === "humidity" ? (it.value != null ? `${Math.round(it.value)}%` : "--%") : it.displayValue}
                           </span>
                         </td>
                         <td className="py-2">
-                          <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                            temp.status === 'Needs Attention' 
-                              ? 'bg-red-100 text-red-800' 
-                              : temp.status === 'Warning'
-                              ? 'bg-yellow-100 text-yellow-800'
-                              : 'bg-green-100 text-green-800'
-                          } ${darkMode ? 'bg-gray-700 text-white' : ''}`}>
-                            {temp.status}
+                          <span
+                            className={`px-2 py-1 rounded-full text-xs font-medium ${
+                              it.status === "Needs Attention"
+                                ? "bg-red-100 text-red-800"
+                                : it.status === "Warning"
+                                ? "bg-yellow-100 text-yellow-800"
+                                : "bg-green-100 text-green-800"
+                            } ${darkMode ? "bg-gray-700 text-white" : ""}`}
+                          >
+                            {it.status}
                           </span>
                         </td>
-                        <td className="py-2 capitalize">{temp.type}</td>
-                        <td className="py-2">
-                          {temp.lastUpdated ? new Date(temp.lastUpdated).toLocaleTimeString() : 'Never'}
-                        </td>
+                        <td className="py-2">{fmtDate(it.lastUpdated, prefs.tz, true)}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -874,8 +814,8 @@ export default function Dashboard() {
             </div>
           </div>
         </div>
-        
-        <footer className={`text-center mt-8 text-sm ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+
+        <footer className={`text-center mt-8 text-sm ${darkMode ? "text-gray-300" : "text-gray-600"}`}>
           © 2025 Safe Sense. All rights reserved.
         </footer>
       </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,61 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Beautiful Scrollbar Styles */
+::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+::-webkit-scrollbar-track {
+  background: #f1f5f9;
+  border-radius: 6px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 6px;
+  border: 2px solid #f1f5f9;
+  transition: background-color 0.2s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #94a3b8;
+}
+
+::-webkit-scrollbar-corner {
+  background: #f1f5f9;
+}
+
+/* Dark mode scrollbar */
+@media (prefers-color-scheme: dark) {
+  ::-webkit-scrollbar-track {
+    background: #1e293b;
+  }
+  
+  ::-webkit-scrollbar-thumb {
+    background: #475569;
+    border-color: #1e293b;
+  }
+  
+  ::-webkit-scrollbar-thumb:hover {
+    background: #64748b;
+  }
+  
+  ::-webkit-scrollbar-corner {
+    background: #1e293b;
+  }
+}
+
+/* Firefox scrollbar */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #cbd5e1 #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+  * {
+    scrollbar-color: #475569 #1e293b;
+  }
+}

--- a/src/app/history/page.js
+++ b/src/app/history/page.js
@@ -1,34 +1,27 @@
-'use client';
+"use client";
 
-import { useState, useRef, useEffect, Component } from 'react';
-import { useRouter } from 'next/navigation';
-import { createClient } from '@supabase/supabase-js';
-import Sidebar from '../../components/Sidebar';
-import { useDarkMode } from '../DarkModeContext';
+import { useEffect, useMemo, useRef, useState, Component } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@supabase/supabase-js";
+import Sidebar from "../../components/Sidebar";
+import { useDarkMode } from "../DarkModeContext";
 
-// Supabase configuration
-const supabaseUrl = 'https://kwaylmatpkcajsctujor.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt3YXlsbWF0cGtjYWpzY3R1am9yIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNDAwMjQsImV4cCI6MjA3MDgxNjAyNH0.-ZICiwnXTGWgPNTMYvirIJ3rP7nQ9tIRC1ZwJBZM96M';
+/* ===== Supabase (read-only) ===== */
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://kwaylmatpkcajsctujor.supabase.co",
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt3YXlsbWF0cGtjYWpzY3R1am9yIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNDAwMjQsImV4cCI6MjA3MDgxNjAyNH0.-ZICiwnXTGWgPNTMYvirIJ3rP7nQ9tIRC1ZwJBZM96M"
+);
 
-let supabase;
-try {
-  supabase = createClient(supabaseUrl, supabaseAnonKey);
-  console.log('Supabase client initialized successfully');
-} catch (err) {
-  console.error('Failed to initialize Supabase client:', err);
-}
-
-// Error Boundary
+/* ===== Error Boundary ===== */
 class ErrorBoundary extends Component {
   state = { hasError: false, error: null };
-  static getDerivedStateFromError(error) {
-    return { hasError: true, error };
-  }
+  static getDerivedStateFromError(error) { return { hasError: true, error }; }
   render() {
     if (this.state.hasError) {
       return (
-        <div className={`p-4 ${this.props.darkMode ? 'text-red-400' : 'text-red-500'}`}>
-          Error: {this.state.error?.message || 'Something went wrong'}
+        <div className={`p-4 ${this.props.darkMode ? "text-red-400" : "text-red-500"}`}>
+          Error: {this.state.error?.message || "Something went wrong"}
         </div>
       );
     }
@@ -36,273 +29,537 @@ class ErrorBoundary extends Component {
   }
 }
 
+/* ===== Time ranges (hours) ===== */
+const RANGES = [
+  { key: "1H",  hours: 1,         label: "Last 1h" },
+  { key: "6H",  hours: 6,         label: "Last 6h" },
+  { key: "12H", hours: 12,        label: "Last 12h" },
+  { key: "24H", hours: 24,        label: "Last 24h" },
+  { key: "1W",  hours: 24 * 7,    label: "Last 1w" },
+  { key: "1M",  hours: 24 * 30,   label: "Last 1m" },
+  { key: "3M",  hours: 24 * 90,   label: "Last 3m" },
+];
+
+const H = 300; // SVG viewBox height
+const W = 100; // SVG viewBox width
+
+/* ===== Helpers ===== */
+const toF = (c) => (c == null ? null : c * 9/5 + 32);
+const toC = (f) => (f == null ? null : (f - 32) * 5/9);
+const fmt1 = (v) => (Math.round(Number(v) * 10) / 10).toLocaleString(undefined, { maximumFractionDigits: 1 });
+
+const epochToIso = (n) => {
+  const t = Number(n);
+  const ms = t > 1e12 ? t : t * 1000; // ms or sec epochs
+  return new Date(ms).toISOString();
+};
+
+const fmtTooltipTime = (iso, timeZone) =>
+  new Date(iso).toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit", second: "2-digit", timeZone });
+
+/* Smart tick labels with seconds when zoomed tight */
+const fmtTickSmart = (ms, visibleMs, baseIsWeekPlus, timeZone) => {
+  const d = new Date(ms);
+  const visibleHours = visibleMs / 3_600_000;
+
+  // If base range is 1W+ we always show a date component
+  if (baseIsWeekPlus) {
+    if (visibleHours >= 24 * 7)
+      return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone });
+    // zoomed into hours or less -> date + time (and seconds when very tight)
+    if (visibleMs <= 6 * 60 * 1000)
+      return d.toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit", second: "2-digit", timeZone });
+    return d.toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit", timeZone });
+  }
+
+  // For base ranges < 1W we adapt to visible width
+  if (visibleMs <= 6 * 60 * 1000) // ≤ 6 minutes -> show seconds
+    return d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", second: "2-digit", timeZone });
+  if (visibleHours < 24)
+    return d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", timeZone });
+  if (visibleHours < 24 * 7)
+    return d.toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", timeZone });
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone });
+};
+
+/* Catmull-Rom → cubic Bézier smoothing */
+const controlPoints = (p0, p1, p2, p3, t = 0.5) => {
+  const d1 = [(p2.x - p0.x) * t, (p2.y - p0.y) * t];
+  const d2 = [(p3.x - p1.x) * t, (p3.y - p1.y) * t];
+  return [
+    { x: p1.x + d1[0] / 3, y: p1.y + d1[1] / 3 },
+    { x: p2.x - d2[0] / 3, y: p2.y - d2[1] / 3 },
+  ];
+};
+const buildSmoothPath = (pts) => {
+  if (!pts.length) return "";
+  if (pts.length === 1) return `M ${pts[0].x},${pts[0].y}`;
+  let d = `M ${pts[0].x},${pts[0].y}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] || pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] || p2;
+    const [c1, c2] = controlPoints(p0, p1, p2, p3, 0.5);
+    d += ` C ${c1.x},${c1.y} ${c2.x},${c2.y} ${p2.x},${p2.y}`;
+  }
+  return d;
+};
+const buildAreaPath = (pts) => {
+  if (!pts.length) return "";
+  const first = pts[0], last = pts[pts.length - 1];
+  const curve = buildSmoothPath(pts).replace(/^M[^C]+/, `L ${first.x},${first.y}`);
+  return `M ${first.x},${H} L ${first.x},${first.y} ${curve} L ${last.x},${H} Z`;
+};
+
 export default function History() {
-  const [selectedSensor, setSelectedSensor] = useState(null);
-  const [selectedTimeRange, setSelectedTimeRange] = useState('1D');
-  const [hoveredPoint, setHoveredPoint] = useState(null);
-  const [sensors, setSensors] = useState([]);
-  const [temperatureData, setTemperatureData] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-  const chartRef = useRef(null);
   const router = useRouter();
   const { darkMode } = useDarkMode();
 
-  // Time range mapping to hours
-  const timeRangeToHours = {
-    '6H': 6,
-    '12H': 12,
-    '1D': 24,
-    '1M': 24 * 30,
-    '3M': 24 * 90,
-  };
+  const [loading, setLoading] = useState(true);
+  const [errMsg, setErrMsg] = useState("");
 
-  // Fallback data
-  const fallbackData = [
-    { x: 0, y: 32, time: '2025-08-18', timeDetail: '12:00 AM' },
-    { x: 1, y: 33, time: '2025-08-18', timeDetail: '1:00 AM' },
-    { x: 2, y: 35, time: '2025-08-18', timeDetail: '2:00 AM' },
-    { x: 3, y: 37, time: '2025-08-18', timeDetail: '3:00 AM' },
-    { x: 4, y: 36, time: '2025-08-18', timeDetail: '4:00 AM' },
-    { x: 5, y: 35, time: '2025-08-18', timeDetail: '5:00 AM' },
-    { x: 6, y: 34, time: '2025-08-18', timeDetail: '6:00 AM' },
-    { x: 7, y: 33, time: '2025-08-18', timeDetail: '7:00 AM' },
-    { x: 8, y: 31, time: '2025-08-18', timeDetail: '8:00 AM' },
-    { x: 9, y: 33, time: '2025-08-18', timeDetail: '9:00 AM' },
-    { x: 10, y: 35, time: '2025-08-18', timeDetail: '10:00 AM' },
-    { x: 11, y: 38, time: '2025-08-18', timeDetail: '11:00 AM' },
-  ];
+  // User prefs
+  const [tempScale, setTempScale] = useState("F"); // 'F'|'C'
+  const [timeZone, setTimeZone] = useState("UTC");
+  const [showTemp, setShowTemp] = useState(true);
+  const [showHumidity, setShowHumidity] = useState(true);
 
-  // Check session
+  // Sensors + selection
+  const [sensors, setSensors] = useState([]); // {sensor_id, name, sensor_type, metric}
+  const [activeSensorId, setActiveSensorId] = useState(null);
+
+  // Range + zoom/pan domain
+  const [rangeKey, setRangeKey] = useState("1H");
+  const rangeHours = useMemo(() => RANGES.find(r => r.key === rangeKey)?.hours ?? 1, [rangeKey]);
+
+  const [zoomDomain, setZoomDomain] = useState(null); // {startMs, endMs} or null
+  const resetZoom = () => setZoomDomain(null);
+
+  // Pan state (drag to navigate when zoomed)
+  const svgWrapRef = useRef(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isPanning, setIsPanning] = useState(false);      // becomes true only after crossing threshold
+  const DRAG_THRESHOLD_PX = 6;                             // prevents accidental pans
+  const dragStart = useRef({ x: 0, startMs: 0, endMs: 0 });
+
+  // Series rows
+  const [rows, setRows] = useState([]); // [{tsISO, value}]
+  const [metric, setMetric] = useState("temperature"); // 'temperature'|'humidity'
+  const [unit, setUnit] = useState("°F"); // '°F'|'°C'|'%'
+
+  // Tooltip
+  const [hovered, setHovered] = useState(null);
+  const chartRef = useRef(null);
+
+  /* ===== Auth + prefs ===== */
   useEffect(() => {
-    const checkSession = async () => {
+    (async () => {
       try {
-        const { data: sessionData, error } = await supabase.auth.getSession();
+        const { data, error } = await supabase.auth.getSession();
         if (error) throw error;
-        if (!sessionData.session) {
-          console.log('No session found, redirecting to login');
-          router.push('/login');
-        }
-      } catch (err) {
-        setError('Failed to verify session: ' + err.message);
-        router.push('/login');
+        if (!data?.session?.user?.id) return router.push("/login");
+
+        const uid = data.session.user.id;
+        const { data: prefs, error: pErr } = await supabase
+          .from("user_preferences")
+          .select("temp_scale, time_zone, show_temp, show_humidity")
+          .eq("user_id", uid)
+          .maybeSingle();
+
+        if (pErr) throw pErr;
+
+        setTempScale((prefs?.temp_scale || "F").toUpperCase());
+        setTimeZone(prefs?.time_zone || "UTC");
+        setShowTemp(prefs?.show_temp ?? true);
+        setShowHumidity(prefs?.show_humidity ?? true);
+      } catch (e) {
+        setErrMsg("Failed to load session or preferences: " + (e?.message || String(e)));
       }
-    };
-    checkSession();
+    })();
   }, [router]);
 
-  // Load sensors and initial data
+  /* ===== Load sensors ===== */
   useEffect(() => {
-    if (!supabase) {
-      setError('Supabase client not initialized');
-      setSensors(['Walk-In Fridge', 'Freezer 1', 'Drive Thru Fridge']);
-      setSelectedSensor('Walk-In Fridge');
-      setTemperatureData(fallbackData);
-      setLoading(false);
-      return;
-    }
-
-    const load = async () => {
+    (async () => {
       try {
-        // Fetch sensors
-        const { data: sensorRows, error: sErr } = await supabase
-          .from('sensors')
-          .select('sensor_id, label')
-          .order('label', { ascending: true });
+        const { data, error } = await supabase
+          .from("sensors")
+          .select("sensor_id, sensor_name, sensor_type, metric")
+          .order("sensor_name", { ascending: true });
 
-        if (sErr) {
-          console.error('Failed to load sensors:', sErr);
-          throw new Error('Failed to load sensors: ' + sErr.message);
-        }
+        if (error) throw error;
 
-        const validSensors = sensorRows
-          .filter(sensor => sensor.sensor_id && sensor.label)
-          .map(sensor => ({
-            sensor_id: sensor.sensor_id,
-            label: sensor.label,
-          }));
+        let list = (data || []).map(r => ({
+          sensor_id: r.sensor_id,
+          name: r.sensor_name || String(r.sensor_id),
+          sensor_type: (r.sensor_type || "sensor").toLowerCase(), // 'sensor'|'temperature'|'humidity'
+          metric: (r.metric || "F").toUpperCase(), // device unit for temp sensors
+        }));
 
-        if (validSensors.length === 0) {
-          throw new Error('No valid sensors found');
-        }
+        // optional filter based on account prefs
+        list = list.filter(s => (s.sensor_type === "humidity" ? showHumidity : showTemp));
 
-        setSensors(validSensors);
-        setSelectedSensor(validSensors[0]?.label || 'Walk-In Fridge');
-
-        // Load initial history for the first sensor
-        await loadHistory(validSensors[0]?.sensor_id, timeRangeToHours[selectedTimeRange]);
-
-      } catch (err) {
-        console.error('Load error:', err);
-        setError('Failed to load data: ' + err.message);
-        setSensors(['Walk-In Fridge', 'Freezer 1', 'Drive Thru Fridge']);
-        setSelectedSensor('Walk-In Fridge');
-        setTemperatureData(fallbackData);
+        setSensors(list);
+        if (list.length) setActiveSensorId(list[0].sensor_id);
+      } catch (e) {
+        setErrMsg("Failed to load sensors: " + (e?.message || String(e)));
       } finally {
         setLoading(false);
       }
-    };
+    })();
+  }, [showTemp, showHumidity]);
 
-    load();
-  }, []);
+  const activeSensor = useMemo(
+    () => sensors.find(s => s.sensor_id === activeSensorId) || null,
+    [sensors, activeSensorId]
+  );
 
-  // Load history for selected sensor and time range
-  const loadHistory = async (sensorId, hours) => {
-    if (!supabase || !sensorId) return;
+  /* metric/unit from sensor_type + user preference */
+  useEffect(() => {
+    if (!activeSensor) return;
+    if (activeSensor.sensor_type === "humidity") {
+      setMetric("humidity");
+      setUnit("%");
+    } else {
+      setMetric("temperature");
+      setUnit(tempScale === "C" ? "°C" : "°F");
+    }
+  }, [activeSensor, tempScale]);
 
-    try {
-      const now = new Date();
-      const from = new Date(now.getTime() - hours * 60 * 60 * 1000);
-      const { data, error } = await supabase
-        .from('raw_readings')
-        .select('value, ts')
-        .eq('source_id', sensorId)
-        .eq('metric', 'temperature')
-        .gte('ts', from.toISOString())
-        .order('ts', { ascending: true })
-        .limit(100);
+  /* ===== Fetch history (approx_time) ===== */
+  useEffect(() => {
+    (async () => {
+      if (!activeSensor) { setRows([]); return; }
+      try {
+        const end = Date.now();
+        const start = end - rangeHours * 3600 * 1000;
+        const fromIso = new Date(start).toISOString();
 
-      if (error) {
-        console.error('Load history error:', error);
-        throw new Error('Failed to load history: ' + error.message);
+        const { data, error } = await supabase
+          .from("raw_readings_v2")
+          .select("reading_value, approx_time, timestamp")
+          .eq("sensor_id", activeSensor.sensor_id)
+          .gte("approx_time", fromIso)
+          .order("approx_time", { ascending: true })
+          .limit(20_000);
+
+        if (error) throw error;
+
+        const deviceMetric = (activeSensor.metric || "F").toUpperCase();
+
+        // humidity never converted; temp converts to user's unit
+        const convert = (v) => {
+          if (metric !== "temperature") return Number(v);
+          if (tempScale === "C" && deviceMetric !== "C") return toC(Number(v));
+          if (tempScale === "F" && deviceMetric !== "F") return toF(Number(v));
+          return Number(v);
+        };
+
+        const cleaned = (data || []).map(r => ({
+          tsISO: r.approx_time || epochToIso(r.timestamp),
+          value: convert(r.reading_value),
+        }));
+
+        setRows(cleaned);
+        setZoomDomain(null); // clear zoom when sensor/range changes
+      } catch (e) {
+        setErrMsg("Failed to load history: " + (e?.message || String(e)));
+        setRows([]);
       }
+    })();
+  }, [activeSensorId, rangeHours, metric, tempScale]);
 
-      const formattedData = data.map((d, i) => ({
-        x: i,
-        y: Number(d.value),
-        time: new Date(d.ts).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }),
-        timeDetail: new Date(d.ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-      }));
-
-      setTemperatureData(formattedData.length > 0 ? formattedData : fallbackData);
-    } catch (err) {
-      console.error('History load error:', err);
-      setError('Failed to load history: ' + err.message);
-      setTemperatureData(fallbackData);
-    }
-  };
-
-  // Update history when sensor or time range changes
+  /* ===== Realtime (unit-aware) ===== */
   useEffect(() => {
-    if (!selectedSensor || loading) return;
-    const sensor = sensors.find(s => s.label === selectedSensor);
-    if (sensor) {
-      loadHistory(sensor.sensor_id, timeRangeToHours[selectedTimeRange]);
-    }
-  }, [selectedSensor, selectedTimeRange, sensors, loading]);
+    if (!activeSensor) return;
 
-  // Realtime updates
-  useEffect(() => {
-    if (!supabase || loading) return;
-
-    const onChange = (payload) => {
-      const r = payload.new || {};
-      if (!r.source_id || r.metric !== 'temperature' || typeof r.value !== 'number') return;
-
-      const sensor = sensors.find(s => s.sensor_id === r.source_id);
-      if (!sensor || sensor.label !== selectedSensor) return;
-
-      setTemperatureData(prev => {
-        const newData = [
-          ...prev,
-          {
-            x: prev.length,
-            y: Number(r.value),
-            time: new Date(r.ts).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }),
-            timeDetail: new Date(r.ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
-          },
-        ].slice(-100); // Keep last 100 points
-        return newData;
-      });
+    const deviceMetric = (activeSensor.metric || "F").toUpperCase();
+    const convert = (v) => {
+      if (metric !== "temperature") return Number(v); // humidity untouched
+      if (tempScale === "C" && deviceMetric !== "C") return toC(Number(v));
+      if (tempScale === "F" && deviceMetric !== "F") return toF(Number(v));
+      return Number(v);
     };
 
     const ch = supabase
-      .channel('raw-readings-history')
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'raw_readings' }, onChange)
+      .channel("rrv2-history")
+      .on("postgres_changes", { event: "INSERT", schema: "public", table: "raw_readings_v2" }, (payload) => {
+        const r = payload.new || {};
+        if (r.sensor_id !== activeSensor.sensor_id) return;
+        if (typeof r.reading_value === "undefined") return;
+        const tsISO = r.approx_time || epochToIso(r.timestamp);
+        setRows(prev => [...prev, { tsISO, value: convert(r.reading_value) }].slice(-20_000));
+      })
       .subscribe();
-
     return () => supabase.removeChannel(ch);
-  }, [selectedSensor, sensors, loading]);
+  }, [activeSensorId, metric, tempScale]);
 
-  // Chart interaction
-  useEffect(() => {
-    const handleMouseMove = (e) => {
-      if (chartRef.current) {
-        const rect = chartRef.current.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
+  /* ===== Chart domain, scaling, geometry ===== */
+  const nowMs = Date.now();
+  const fullStartMs = nowMs - rangeHours * 3600 * 1000; // entire selected range
+  const domainStart = zoomDomain?.startMs ?? fullStartMs;
+  const domainEnd   = zoomDomain?.endMs   ?? nowMs;
+  const visibleMs   = domainEnd - domainStart;
 
-        let closestPoint = null;
-        let minDistance = Infinity;
+  const scaleXTime = (ms) => {
+    const t = (ms - domainStart) / Math.max(1, visibleMs);
+    return Math.max(0, Math.min(1, t)) * W;
+  };
 
-        temperatureData.forEach((point, i) => {
-          const pointX = (i / (temperatureData.length - 1)) * (rect.width - 40);
-          const pointY = 300 - ((point.y - 10) / 50) * 300;
-          const distance = Math.sqrt(Math.pow(x - pointX, 2) + Math.pow(y - pointY, 2));
+  // Y bounds adapt to data and unit
+  const yBounds = useMemo(() => {
+    if (!rows.length) {
+      return metric === "humidity" ? { min: 0, max: 100 }
+           : tempScale === "C"    ? { min: -20, max: 40 }
+                                  : { min: -10, max: 80 };
+    }
+    const vals = rows.map(r => r.value).filter(Number.isFinite);
+    if (!vals.length) {
+      return metric === "humidity" ? { min: 0, max: 100 }
+           : tempScale === "C"    ? { min: -20, max: 40 }
+                                  : { min: -10, max: 80 };
+    }
+    let min = Math.min(...vals), max = Math.max(...vals);
+    const pad = metric === "humidity" ? 5 : (tempScale === "C" ? 2 : 3);
+    min = Math.floor(min - pad); max = Math.ceil(max + pad);
+    if (metric === "humidity") { min = Math.max(0, min); max = Math.min(100, Math.max(10, max)); }
+    if (min === max) { min -= 1; max += 1; }
+    return { min, max };
+  }, [rows, metric, tempScale]);
 
-          if (distance < 25 && distance < minDistance) {
-            minDistance = distance;
-            closestPoint = { ...point, index: i };
-          }
-        });
+  const scaleY = (v) => {
+    const { min, max } = yBounds;
+    const clamped = Math.max(min, Math.min(v, max));
+    return H - ((clamped - min) / (max - min)) * H;
+  };
 
-        setHoveredPoint(closestPoint);
+  // Positioned points within current domain
+  const points = useMemo(() => {
+    return rows.map(r => {
+      const ms = new Date(r.tsISO).getTime();
+      return { tsISO: r.tsISO, ms, x: scaleXTime(ms), y: scaleY(r.value), value: r.value };
+    }).filter(p => p.ms >= domainStart && p.ms <= domainEnd);
+  }, [rows, domainStart, domainEnd, yBounds]);
+
+  // Gap detection (≥ 5 minutes)
+  const GAP_MS = 5 * 60 * 1000;
+  const { segments, gaps } = useMemo(() => {
+    const segs = [];
+    const grey = [];
+
+    if (!points.length) return { segments: segs, gaps: grey };
+
+    let cur = [points[0]];
+    for (let i = 1; i < points.length; i++) {
+      const prev = points[i - 1];
+      const p = points[i];
+      if (p.ms - prev.ms >= GAP_MS) {
+        if (cur.length) segs.push(cur);
+        grey.push({ x1: scaleXTime(prev.ms), x2: scaleXTime(p.ms) });
+        cur = [p];
+      } else {
+        cur.push(p);
       }
-    };
+    }
+    if (cur.length) segs.push(cur);
 
-    const handleMouseLeave = () => setHoveredPoint(null);
-
-    const chartElement = chartRef.current;
-    if (chartElement) {
-      chartElement.addEventListener('mousemove', handleMouseMove);
-      chartElement.addEventListener('mouseleave', handleMouseLeave);
+    // Leading gap (window start → first)
+    const first = points[0];
+    if (first && first.ms - domainStart >= GAP_MS) {
+      grey.unshift({ x1: scaleXTime(domainStart), x2: scaleXTime(first.ms) });
+    }
+    // Trailing gap (last → window end)
+    const last = points[points.length - 1];
+    if (last && domainEnd - last.ms >= GAP_MS) {
+      grey.push({ x1: scaleXTime(last.ms), x2: scaleXTime(domainEnd) });
     }
 
-    return () => {
-      if (chartElement) {
-        chartElement.removeEventListener('mousemove', handleMouseMove);
-        chartElement.removeEventListener('mouseleave', handleMouseLeave);
+    return { segments: segs, gaps: grey };
+  }, [points, domainStart, domainEnd]);
+
+  // Ticks based on *visible* domain; more ticks when zoomed very tight
+  const tickCount = visibleMs <= 6 * 60 * 1000 ? 8 : 6;
+  const baseIsWeekPlus = ["1W", "1M", "3M"].includes(rangeKey);
+  const ticks = useMemo(() => {
+    const step = visibleMs / (tickCount - 1);
+    return Array.from({ length: tickCount }, (_, i) => domainStart + i * step);
+  }, [domainStart, visibleMs, tickCount]);
+
+  // Tooltip: nearest by x
+  useEffect(() => {
+    const onMove = (e) => {
+      const el = chartRef.current;
+      if (!el || !points.length) return;
+      const rect = el.getBoundingClientRect();
+      const px = ((e.clientX - rect.left) / rect.width) * W;
+      let best = Infinity, pick = null;
+      for (let i = 0; i < points.length; i++) {
+        const d = Math.abs(px - points[i].x);
+        if (d < best) { best = d; pick = points[i]; }
       }
+      setHovered(pick);
     };
-  }, [temperatureData]);
+    const onLeave = () => setHovered(null);
+    const el = chartRef.current;
+    if (el) { el.addEventListener("mousemove", onMove); el.addEventListener("mouseleave", onLeave); }
+    return () => { if (el) { el.removeEventListener("mousemove", onMove); el.removeEventListener("mouseleave", onLeave); } };
+  }, [points]);
 
-  const getLinePath = () => {
-    if (!temperatureData.length) return '';
-    const height = 300;
-    const width = 100;
-    return temperatureData
-      .map((point, i) => {
-        const x = (i / (temperatureData.length - 1)) * width;
-        const y = height - ((point.y - 10) / 50) * height;
-        return `${x},${y}`;
-      })
-      .join(' L ');
-  };
+  /* ===== Zoom (wheel/pinch) & Pan (drag with threshold) ===== */
+  useEffect(() => {
+    const wrap = svgWrapRef.current;
+    if (!wrap) return;
 
-  const getAreaPath = () => {
-    if (!temperatureData.length) return '';
-    const height = 300;
-    const width = 100;
-    const points = temperatureData.map((point, i) => {
-      const x = (i / (temperatureData.length - 1)) * width;
-      const y = height - ((point.y - 10) / 50) * height;
-      return `${x},${y}`;
-    });
-    const firstPoint = points[0].split(',');
-    const lastPoint = points[points.length - 1].split(',');
-    return `M ${firstPoint[0]},${height} L ${points.join(' L ')} L ${lastPoint[0]},${height} Z`;
-  };
+    // --- Zoom on wheel or pinch ---
+    const onWheel = (e) => {
+      e.preventDefault(); // enables pinch zoom on trackpads too
+      const rect = wrap.getBoundingClientRect();
+      const t = Math.max(0, Math.min(1, e.offsetX / rect.width));
+      const center = domainStart + t * visibleMs;
 
-  // Loading state
-  if (loading) {
+      const factor = e.deltaY < 0 ? 0.85 : 1.15; // in/out
+      let newStart = center - (center - domainStart) * factor;
+      let newEnd   = center + (domainEnd - center) * factor;
+
+      // Minimum window 2 minutes
+      const MIN = 2 * 60 * 1000;
+      if (newEnd - newStart < MIN) {
+        const mid = (newStart + newEnd) / 2;
+        newStart = mid - MIN / 2;
+        newEnd   = mid + MIN / 2;
+      }
+
+      // Clamp to full selected range
+      const fullStart = fullStartMs;
+      const fullEnd   = nowMs;
+      newStart = Math.max(fullStart, newStart);
+      newEnd   = Math.min(fullEnd, newEnd);
+
+      setZoomDomain({ startMs: newStart, endMs: newEnd });
+    };
+
+    // --- Pan by dragging when zoomed in (NOT on click) ---
+    const canPan = visibleMs < (nowMs - fullStartMs) - 500;
+    const onDown = (e) => {
+      if (!canPan || e.button !== 0) return;
+      setIsDragging(true);
+      setIsPanning(false); // becomes true after threshold
+      dragStart.current = { x: e.clientX, startMs: domainStart, endMs: domainEnd };
+    };
+    const onMove = (e) => {
+      if (!isDragging) return;
+      const rect = wrap.getBoundingClientRect();
+      const dx = e.clientX - dragStart.current.x;
+
+      // ignore small movements so clicks don't pan
+      if (!isPanning && Math.abs(dx) < DRAG_THRESHOLD_PX) return;
+      if (!isPanning) setIsPanning(true);
+
+      const frac = dx / rect.width;           // pixels → fraction
+      const shift = -frac * (dragStart.current.endMs - dragStart.current.startMs);
+      let newStart = dragStart.current.startMs + shift;
+      let newEnd   = dragStart.current.endMs + shift;
+
+      // clamp to full range
+      const span = newEnd - newStart;
+      if (newStart < fullStartMs) { newStart = fullStartMs; newEnd = fullStartMs + span; }
+      if (newEnd > nowMs) { newEnd = nowMs; newStart = nowMs - span; }
+
+      setZoomDomain({ startMs: newStart, endMs: newEnd });
+    };
+    const onUp = () => {
+      setIsDragging(false);
+      setIsPanning(false);
+    };
+
+    wrap.addEventListener("wheel", onWheel, { passive: false });
+    wrap.addEventListener("mousedown", onDown);
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+
+    return () => {
+      wrap.removeEventListener("wheel", onWheel);
+      wrap.removeEventListener("mousedown", onDown);
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [visibleMs, domainStart, domainEnd, nowMs, fullStartMs]);
+
+  /* ===== UI helpers ===== */
+  const RangeButtons = () => (
+    <div className="flex gap-2">
+      {RANGES.map((r) => {
+        const active = r.key === rangeKey;
+        return (
+          <button
+            key={r.key}
+            onClick={() => { setRangeKey(r.key); resetZoom(); }}
+            className={`px-2.5 py-1.5 rounded-md border text-xs transition
+              ${active
+                ? (darkMode ? "bg-emerald-600 border-emerald-600 text-white" : "bg-emerald-500 border-emerald-500 text-white")
+                : (darkMode ? "bg-gray-700 border-gray-600 text-gray-200 hover:bg-gray-600" : "bg-white border-gray-300 hover:bg-gray-50")}`}
+          >
+            {r.key}
+          </button>
+        );
+      })}
+      <button
+        onClick={resetZoom}
+        className={`px-2.5 py-1.5 rounded-md border text-xs ${
+          darkMode ? "bg-gray-700 border-gray-600 text-gray-200 hover:bg-gray-600" : "bg-white border-gray-300 hover:bg-gray-50"
+        }`}
+        title="Reset zoom"
+      >
+        Reset
+      </button>
+    </div>
+  );
+useEffect(() => {
+  if (!activeSensor) return;
+  const isHumidity = (activeSensor.sensor_type || "").toLowerCase() === "humidity";
+
+  if (isHumidity) {
+    setMetric("humidity");
+    setUnit("%");                 // never tied to tempScale
+  } else {
+    setMetric("temperature");
+    setUnit(tempScale === "C" ? "°C" : "°F");
+  }
+}, [activeSensor, tempScale]);
+
+  const SensorButtons = () => (
+    <div className="flex flex-wrap gap-2">
+      {sensors.map((s) => {
+        const active = s.sensor_id === activeSensorId;
+        return (
+          <button
+            key={s.sensor_id}
+            onClick={() => { setActiveSensorId(s.sensor_id); resetZoom(); }}
+            className={`px-3 py-1.5 rounded-full border text-sm transition
+              ${active
+                ? (darkMode ? "bg-blue-600 border-blue-600 text-white" : "bg-blue-500 border-blue-500 text-white")
+                : (darkMode ? "bg-gray-700 border-gray-600 text-gray-200 hover:bg-gray-600" : "bg-white border-gray-300 hover:bg-gray-50")}`}
+            title={s.sensor_type === "humidity" ? "Humidity sensor" : "Temperature sensor"}
+          >
+            {s.name}
+          </button>
+        );
+      })}
+      {!sensors.length && <span className={darkMode ? "text-gray-400" : "text-gray-500"}>No sensors found</span>}
+    </div>
+  );
+
+  /* ===== Loading skeleton ===== */
+  if (loading && !sensors.length) {
     return (
       <ErrorBoundary darkMode={darkMode}>
-        <div className={`flex min-h-screen ${darkMode ? 'bg-gray-800 text-white' : 'bg-gray-100 text-gray-800'}`}>
+        <div className={`flex min-h-screen ${darkMode ? "bg-gray-800 text-white" : "bg-gray-100 text-gray-800"}`}>
           <Sidebar activeKey="history" darkMode={darkMode} />
           <main className="flex-1 p-6 flex items-center justify-center">
             <div className="text-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-500 mx-auto mb-4"></div>
-              <p>Loading history data...</p>
+              <p>Loading history…</p>
             </div>
           </main>
         </div>
@@ -310,150 +567,169 @@ export default function History() {
     );
   }
 
+  const empty = points.length === 0;
+
+  /* ===== Render ===== */
   return (
     <ErrorBoundary darkMode={darkMode}>
-      <div className={`flex min-h-screen ${darkMode ? 'bg-gray-800 text-gray-300' : 'bg-gray-100 text-gray-800'}`}>
+      <div className={`flex min-h-screen ${darkMode ? "bg-gray-800 text-gray-200" : "bg-gray-100 text-gray-800"}`}>
         <Sidebar activeKey="history" darkMode={darkMode} />
         <main className="flex-1 p-6">
+          {/* Header */}
           <div className="flex justify-between items-center mb-6">
             <h2 className="text-3xl font-bold">History</h2>
-            <div className="flex items-center space-x-4">
-              {error && <p className="text-red-500 text-sm">{error}</p>}
+            <div className="flex items-center space-x-3">
+              {errMsg && <p className="text-red-500 text-sm">{errMsg}</p>}
               <button
                 onClick={async () => {
-                  try {
-                    const { error } = await supabase.auth.signOut();
-                    if (error) throw error;
-                    router.push('/login');
-                  } catch (err) {
-                    setError('Failed to sign out: ' + err.message);
-                  }
+                  try { const { error } = await supabase.auth.signOut(); if (error) throw error; router.push("/login"); }
+                  catch (e) { setErrMsg("Failed to sign out: " + (e?.message || String(e))); }
                 }}
-                className={`px-4 py-2 rounded ${darkMode ? 'bg-red-700 text-white hover:bg-red-800' : 'bg-red-500 text-white hover:bg-red-600'}`}
+                className={`px-4 py-2 rounded ${darkMode ? "bg-red-700 text-white hover:bg-red-800" : "bg-red-500 text-white hover:bg-red-600"}`}
               >
                 Log out
               </button>
-              <div className={`w-10 h-10 ${darkMode ? 'bg-amber-700' : 'bg-amber-600'} rounded-full flex items-center justify-center text-white text-sm font-bold`}>
-                FA
-              </div>
+              <div className={`${darkMode ? "bg-amber-700" : "bg-amber-600"} w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-bold`}>FA</div>
             </div>
           </div>
 
-          <div className={`rounded-lg shadow p-6 border-2 ${darkMode ? 'bg-gray-800 border-blue-700' : 'bg-white border-blue-300'}`}>
-            <div className="mb-6">
-              <h3 className="text-xl font-semibold">Temperature History</h3>
-              <p className={`text-sm ${darkMode ? 'text-green-400' : 'text-green-700'}`}>
-                {selectedSensor || 'No sensor selected'}
-              </p>
-            </div>
-            <div className="flex justify-end items-center space-x-2 mb-6">
-              <select
-                value={selectedSensor || ''}
-                onChange={(e) => setSelectedSensor(e.target.value)}
-                className={`border rounded px-2 py-1 ${darkMode ? 'bg-gray-700 text-gray-300 border-gray-600' : 'bg-white text-gray-900 border-gray-300'}`}
-              >
-                {sensors.length === 0 && <option value="">No sensors available</option>}
-                {sensors.map((sensor) => (
-                  <option key={sensor.sensor_id} value={sensor.label}>
-                    {sensor.label}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={selectedTimeRange}
-                onChange={(e) => setSelectedTimeRange(e.target.value)}
-                className={`border rounded px-2 py-1 ${darkMode ? 'bg-gray-700 text-gray-300 border-gray-600' : 'bg-white text-gray-900 border-gray-300'}`}
-              >
-                {['6H', '12H', '1D', '1M', '3M'].map((range) => (
-                  <option key={range} value={range}>
-                    {range}
-                  </option>
-                ))}
-              </select>
+          {/* Card */}
+          <div className={`rounded-lg shadow p-6 ${darkMode ? "bg-gray-800 border-blue-700" : "bg-white border-blue-300"} border`}>
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+              <div>
+                <h3 className="text-xl font-semibold">Sensor History</h3>
+                <p className={`${darkMode ? "text-green-400" : "text-green-700"} text-sm`}>
+                  {activeSensor
+                    ? `${activeSensor.name} • ${metric === "humidity" ? "Humidity" : `Temperature (${unit})`}`
+                    : "Select a sensor"}
+                </p>
+              </div>
+              <RangeButtons />
             </div>
 
+            <div className="mb-4 overflow-x-auto pb-2">
+              <SensorButtons />
+            </div>
+
+            {/* Chart */}
             <div className="relative">
               <div className="flex">
+                {/* Left Y-axis */}
                 <div className="flex flex-col items-end pr-4 mr-4">
-                  <div className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-600'} transform -rotate-90 origin-bottom-left absolute top-1/2 -translate-y-1/2 -left-8 w-64 text-center font-medium`}>
-                    Temperature (Fahrenheit)
+                  <div className={`text-sm ${darkMode ? "text-gray-400" : "text-gray-600"} transform -rotate-90 origin-bottom-left absolute top-1/2 -translate-y-1/2 -left-8 w-64 text-center font-medium`}>
+                    {metric === "humidity" ? "Humidity (%)" : `Temperature (${unit})`}
                   </div>
-                  <div className="flex flex-col justify-between h-80 text-sm text-gray-500">
-                    {[60, 50, 40, 30, 20, 10].map((val) => (
-                      <div key={val} className="flex items-center">
-                        <span className={`leading-none mr-3 w-6 text-right ${darkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-                          {val}
-                        </span>
-                        <div className={`w-2 border-t ${darkMode ? 'border-gray-600' : 'border-gray-300'}`}></div>
-                      </div>
-                    ))}
+                  <div className="flex flex-col justify-between h-80 text-sm">
+                    {(() => {
+                      const { min, max } = yBounds;
+                      const steps = 6;
+                      const ticksY = Array.from({ length: steps + 1 }, (_, i) =>
+                        Math.round(max - (i * (max - min)) / steps)
+                      );
+                      return ticksY.map((val, idx) => (
+                        <div key={idx} className="flex items-center">
+                          <span className={`${darkMode ? "text-gray-400" : "text-gray-500"} leading-none mr-3 w-14 text-right`}>
+                            {val}
+                          </span>
+                          <div className={`w-2 border-t ${darkMode ? "border-gray-600" : "border-gray-300"}`}></div>
+                        </div>
+                      ));
+                    })()}
                   </div>
                 </div>
 
-                <div className="flex-1 relative" ref={chartRef}>
-                  <div className="h-80 relative">
-                    <svg width="100%" height="300" viewBox="0 0 100 300" preserveAspectRatio="none" className={`border-b border-l ${darkMode ? 'border-gray-600' : 'border-gray-300'}`}>
-                      {[10, 20, 30, 40, 50, 60].map((val) => (
-                        <line
-                          key={val}
-                          x1="0"
-                          y1={300 - ((val - 10) / 50) * 300}
-                          x2="100"
-                          y2={300 - ((val - 10) / 50) * 300}
-                          stroke={darkMode ? '#4b5563' : '#e5e7eb'}
-                          strokeWidth="0.2"
-                          strokeDasharray="1,1"
-                          vectorEffect="non-scaling-stroke"
+                {/* Plot area (wheel zoom + drag pan with threshold) */}
+                <div className="flex-1 relative">
+                  <div
+                    ref={svgWrapRef}
+                    className={`h-80 relative ${isDragging || isPanning ? "cursor-grabbing" : (visibleMs < (nowMs - fullStartMs) - 500 ? "cursor-grab" : "cursor-default")}`}
+                  >
+                    <svg
+                      ref={chartRef}
+                      width="100%"
+                      height={H}
+                      viewBox={`0 0 ${W} ${H}`}
+                      preserveAspectRatio="none"
+                      className={`border-b border-l ${darkMode ? "border-gray-600" : "border-gray-300"}`}
+                    >
+                      {/* grid */}
+                      {Array.from({ length: 7 }).map((_, i) => {
+                        const y = (i / 6) * H;
+                        return (
+                          <line
+                            key={i}
+                            x1="0" y1={y} x2={W} y2={y}
+                            stroke={darkMode ? "#4b5563" : "#e5e7eb"}
+                            strokeWidth="0.2" strokeDasharray="1,1"
+                            vectorEffect="non-scaling-stroke"
+                          />
+                        );
+                      })}
+
+                      {/* grey gaps */}
+                      {gaps.map((g, idx) => (
+                        <rect
+                          key={`gap-${idx}`}
+                          x={g.x1}
+                          y={0}
+                          width={Math.max(0, g.x2 - g.x1)}
+                          height={H}
+                          fill={darkMode ? "rgba(156,163,175,0.20)" : "rgba(156,163,175,0.20)"}
                         />
                       ))}
-                      <path
-                        d={getAreaPath()}
-                        fill={darkMode ? 'rgba(34, 197, 94, 0.3)' : 'rgba(34, 197, 94, 0.2)'}
-                        stroke="none"
-                      />
-                      <path
-                        d={getLinePath()}
-                        fill="none"
-                        stroke="#22c55e"
-                        strokeWidth="1"
-                        vectorEffect="non-scaling-stroke"
-                      />
-                      {temperatureData.map((point, i) => (
-                        <circle
-                          key={i}
-                          cx={(i / (temperatureData.length - 1)) * 100}
-                          cy={300 - ((point.y - 10) / 50) * 300}
-                          r="1.5"
-                          fill="#22c55e"
-                          stroke={darkMode ? '#374151' : 'white'}
-                          strokeWidth="0.5"
-                          vectorEffect="non-scaling-stroke"
-                          className="cursor-pointer hover:r-3 transition-all"
-                        />
-                      ))}
+
+                      {/* Segments: area + smooth line */}
+                      {segments.length ? (
+                        segments.map((seg, idx) => {
+                          const path = buildSmoothPath(seg);
+                          const area = buildAreaPath(seg);
+                          return (
+                            <g key={`seg-${idx}`}>
+                              <path d={area} fill={darkMode ? "rgba(34,197,94,0.22)" : "rgba(34,197,94,0.18)"} />
+                              <path d={path} fill="none" stroke="#22c55e" strokeWidth="1.4" vectorEffect="non-scaling-stroke" />
+                            </g>
+                          );
+                        })
+                      ) : null}
                     </svg>
-                    {hoveredPoint && (
+
+                    {/* Clean “No data” overlay (HTML, not SVG, so it never skews) */}
+                    {segments.length === 0 && (
+                      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                        <div className={`${darkMode ? "text-gray-400" : "text-gray-500"} text-sm font-medium`}>
+                          No data in {RANGES.find(r => r.key === rangeKey)?.label || "range"}
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Tooltip */}
+                    {hovered && (
                       <div
                         className="absolute pointer-events-none z-10"
                         style={{
-                          left: `${(hoveredPoint.index / (temperatureData.length - 1)) * 100}%`,
-                          top: `${300 - ((hoveredPoint.y - 10) / 50) * 300 - 90}px`,
-                          transform: 'translateX(-50%)',
+                          left: `${(hovered.x / W) * 100}%`,
+                          top: `${hovered.y - 80}px`,
+                          transform: "translateX(-50%)",
                         }}
                       >
-                        <div className={`${darkMode ? 'bg-green-600' : 'bg-green-500'} text-white p-3 rounded-lg shadow-lg border-2 ${darkMode ? 'border-gray-600' : 'border-white'} text-center min-w-32`}>
-                          <div className="text-xs font-medium">Temperature</div>
-                          <div className="text-lg font-bold">{hoveredPoint.y}°F</div>
-                          <div className="text-xs">{hoveredPoint.time}</div>
-                          <div className="text-xs font-semibold">{hoveredPoint.timeDetail}</div>
+                        <div className="bg-green-500 text-white p-3 rounded-lg shadow-lg border-2 border-white text-center min-w-36">
+                          <div className="text-xs font-medium">{metric === "humidity" ? "Humidity" : "Temperature"}</div>
+                          <div className="text-xl font-extrabold leading-tight">
+                            {metric === "humidity"
+                              ? `${fmt1(hovered.value)}%`
+                              : `${fmt1(hovered.value)}${unit}`}
+                          </div>
+                          <div className="text-xs mt-0.5">{fmtTooltipTime(hovered.tsISO, timeZone)}</div>
                         </div>
-                        <div className={`w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent ${darkMode ? 'border-t-green-600' : 'border-t-green-500'} mx-auto`}></div>
+                        <div className="w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-green-500 mx-auto" />
                       </div>
                     )}
+
+                    {/* X-axis ticks */}
                     <div className="absolute -bottom-6 left-0 right-0 flex justify-between px-2">
-                      {['6H', '12H', '1D', '1M', '3M'].map((label) => (
-                        <span key={label} className={`text-xs ${darkMode ? 'text-gray-400' : 'text-gray-600'} font-medium`}>
-                          {label}
+                      {ticks.map((t, i) => (
+                        <span key={i} className={darkMode ? "text-gray-400 text-xs" : "text-gray-600 text-xs"}>
+                          {fmtTickSmart(t, visibleMs, baseIsWeekPlus, timeZone)}
                         </span>
                       ))}
                     </div>
@@ -461,7 +737,13 @@ export default function History() {
                 </div>
               </div>
             </div>
+            
+            <div className={`mt-10 text-xs ${darkMode ? "text-gray-400" : "text-gray-500"}`}>
+              Zoom with <span className="font-semibold">scroll/pinch</span>. When zoomed, <span className="font-semibold">drag</span> to pan. Clicks alone won’t move the chart. Use <span className="font-semibold">Reset</span> to return.
+            </div>
+            
           </div>
+          
         </main>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
Database

sensors.sensor_type added (sensor | temperature | humidity, default sensor).

user_preferences.show_temp & show_humidity added (default true).

Accounts page

Saves show_temp, show_humidity, temp_scale, time_zone, dark_mode into user_preferences.

Dashboard page

Reads sensor_type to treat humidity like temperature.

“All” view respects show_temp / show_humidity (only charts enabled kinds).

Filter dropdown hides Temperature/Humidity options when disabled.

Dual y-axes shown only for visible kinds; empty chart state when nothing to plot.