### PR TITLE
Fixed : new alert stage, Logout, Time zones, Avatar Display, Display Name, live fetch issues, 

### DIFF
--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -127,6 +127,12 @@ export default function Dashboard() {
   const [username, setUsername] = useState("User");
   const [error, setError] = useState("");
 
+  // Mounted timestamp for hydration-safe "Last updated" display
+  const [nowTs, setNowTs] = useState(null);
+  useEffect(() => {
+    setNowTs(Date.now());
+  }, []);
+
   // Preferences (from user_preferences)
   const [prefs, setPrefs] = useState({
     unit: "F", // 'F' | 'C' (temperature display)
@@ -188,6 +194,9 @@ export default function Dashboard() {
           };
           setPrefs(next);
           if (!!row.dark_mode !== darkMode) toggleDarkMode();
+          if (row.username) {
+            setUsername(String(row.username));
+          }
         }
       } catch (err) {
         setError("Failed to verify session: " + (err?.message || String(err)));
@@ -206,7 +215,7 @@ export default function Dashboard() {
           id: id++,
           title: `${it.status} (${it.name})`,
           description: it.kind === "humidity" ? `Humidity: ${it.displayValue}` : `Temperature: ${it.displayValue}`,
-          date: fmtDate(Date.now(), tz, false),
+          date: fmtDate(nowTs || Date.now(), tz, false),
           type: it.status === "Needs Attention" ? "error" : "warning",
           sensorId: it.sensor_id,
         });
@@ -639,7 +648,7 @@ export default function Dashboard() {
                 : axisTemp.title}
             </h3>
             <div className="flex items-center gap-3">
-              <div className="text-sm text-gray-500">Last updated: {fmtDate(Date.now(), prefs.tz, true)}</div>
+              <div className="text-sm text-gray-500">Last updated: <span suppressHydrationWarning>{nowTs ? fmtDate(nowTs, prefs.tz, true) : "—"}</span></div>
               <div className="flex items-center gap-2">
                 <label className={`text-sm ${darkMode ? "text-gray-300" : "text-gray-600"}`}>Filter:</label>
                 <select


### PR DESCRIPTION
### Dashboard
- Use sensors.latest_temp and last_fetched_time; realtime via sensors UPDATE channel.
- Offline rule: mark Unconfigured if last_fetched_time ≥ 30 min; show “NA” for Unconfigured readings.
- All times formatted in user’s Account timezone; hydration-safe “Last updated”.
- Avatar shows initials from user_preferences.username; greeting updated accordingly.

### Alerts
- Display “NA” when a sensor is Unconfigured (cards and detail view).
- Chart/tooltips and “Last Reading” respect Account timezone.
- Logout button matches Dashboard styling; avatar shows user initials.

### History
- Graphs now use raw_readings_v2.fetched_at for timestamps and reading_value for values (fetch + realtime).
- Logout button updated to Dashboard styling; avatar shows initials from user_preferences.username (fallback to email prefix).

### Account (Settings)
- Added editable “User name” field stored in user_preferences.username.
- Time Zone dropdown marks the browser’s timezone with “(current)”.
- Logout and avatar unchanged functionally; persists all existing preferences.

### Misc
- Consistent “NA” handling for Unconfigured sensors across Dashboard and Alerts.
- Reduced hydration issues by deferring client time and using suppressHydrationWarning where needed.